### PR TITLE
Fix NullReferenceException

### DIFF
--- a/Library/DiscUtils.Core/Vfs/VfsFileSystem.cs
+++ b/Library/DiscUtils.Core/Vfs/VfsFileSystem.cs
@@ -529,7 +529,7 @@ namespace DiscUtils.Vfs
 
             TDirEntry dirEntry = GetDirectoryEntry(path);
 
-            if (dirEntry.IsSymlink)
+            if (dirEntry != null && dirEntry.IsSymlink)
             {
                 dirEntry = ResolveSymlink(dirEntry, path);
             }


### PR DESCRIPTION
Check result of GetDirectoryEntry() for null before trying to reference
it.