### PR TITLE
Fix iso-9660 detection

### DIFF
--- a/Library/DiscUtils.Iso9660/BaseVolumeDescriptor.cs
+++ b/Library/DiscUtils.Iso9660/BaseVolumeDescriptor.cs
@@ -27,27 +27,23 @@ namespace DiscUtils.Iso9660
 {
     internal class BaseVolumeDescriptor
     {
-        private const string Iso9660StandardIdentifier = "CD001";
+        public const string Iso9660StandardIdentifier = "CD001";
 
+        public readonly string StandardIdentifier;
         public readonly VolumeDescriptorType VolumeDescriptorType;
         public readonly byte VolumeDescriptorVersion;
 
         public BaseVolumeDescriptor(VolumeDescriptorType type, byte version)
         {
             VolumeDescriptorType = type;
+            StandardIdentifier = "CD001";
             VolumeDescriptorVersion = version;
         }
 
         public BaseVolumeDescriptor(byte[] src, int offset)
         {
-            string identifier = Encoding.ASCII.GetString(src, offset + 1, 5);
-
-            if (identifier != Iso9660StandardIdentifier)
-            {
-                throw new InvalidFileSystemException("Volume is not ISO-9660");
-            }
-
             VolumeDescriptorType = (VolumeDescriptorType)src[offset + 0];
+            StandardIdentifier = Encoding.ASCII.GetString(src, offset + 1, 5);
             VolumeDescriptorVersion = src[offset + 6];
         }
 
@@ -57,11 +53,6 @@ namespace DiscUtils.Iso9660
             buffer[offset] = (byte)VolumeDescriptorType;
             IsoUtilities.WriteAChars(buffer, offset + 1, 5, StandardIdentifier);
             buffer[offset + 6] = VolumeDescriptorVersion;
-        }
-
-        public string StandardIdentifier
-        {
-            get { return Iso9660StandardIdentifier; }
         }
     }
 }

--- a/Library/DiscUtils.Iso9660/CDReader.cs
+++ b/Library/DiscUtils.Iso9660/CDReader.cs
@@ -191,7 +191,8 @@ namespace DiscUtils.Iso9660
             }
 
             BaseVolumeDescriptor bvd = new BaseVolumeDescriptor(buffer, 0);
-            return bvd.StandardIdentifier == "CD001";
+
+            return bvd.StandardIdentifier == BaseVolumeDescriptor.Iso9660StandardIdentifier;
         }
 
         /// <summary>

--- a/Library/DiscUtils.Iso9660/VfsCDReader.cs
+++ b/Library/DiscUtils.Iso9660/VfsCDReader.cs
@@ -92,6 +92,12 @@ namespace DiscUtils.Iso9660
                 }
 
                 bvd = new BaseVolumeDescriptor(buffer, 0);
+
+                if (bvd.StandardIdentifier != BaseVolumeDescriptor.Iso9660StandardIdentifier)
+                {
+                    throw new InvalidFileSystemException("Volume is not ISO-9660");
+                }
+
                 switch (bvd.VolumeDescriptorType)
                 {
                     case VolumeDescriptorType.Boot:


### PR DESCRIPTION
I broke iso-9660 file detection in one of my previous commits. This fixes it, while retaining the enforcement when opening a file.