### PR TITLE
Xfs Bugfixes & Test

### DIFF
--- a/Library/DiscUtils.Xfs/AllocationGroup.cs
+++ b/Library/DiscUtils.Xfs/AllocationGroup.cs
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2008-2011, Kenneth Bell
 // Copyright (c) 2016, Bianco Veigel
+// Copyright (c) 2017, Timo Walter
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -47,27 +48,19 @@ namespace DiscUtils.Xfs
             Context = context;
             var data = context.RawStream;
             var superblock = context.SuperBlock;
-            FreeBlockInfo = new AllocationGroupFreeBlockInfo();
+            FreeBlockInfo = new AllocationGroupFreeBlockInfo(superblock);
             data.Position = offset + superblock.SectorSize;
-            var agfData = Utilities.ReadFully(data, FreeBlockInfo.InitSize(superblock.SbVersion)); 
+            var agfData = Utilities.ReadFully(data, FreeBlockInfo.Size); 
             FreeBlockInfo.ReadFrom(agfData, 0);
-            if (superblock.SbVersion >= 5)
-            {
-                FreeBlockInfo.ReadFromVersion5(agfData, 0);
-            }
             if (FreeBlockInfo.Magic != AllocationGroupFreeBlockInfo.AgfMagic)
             {
                 throw new IOException("Invalid AGF magic - probably not an xfs file system");
             }
 
-            InodeBtreeInfo = new AllocationGroupInodeBtreeInfo();
+            InodeBtreeInfo = new AllocationGroupInodeBtreeInfo(superblock);
             data.Position = offset + superblock.SectorSize * 2;
-            var agiData = Utilities.ReadFully(data, InodeBtreeInfo.InitSize(superblock.SbVersion));
+            var agiData = Utilities.ReadFully(data, InodeBtreeInfo.Size);
             InodeBtreeInfo.ReadFrom(agiData, 0);
-            if (superblock.SbVersion >= 5)
-            {
-                InodeBtreeInfo.ReadFromVersion5(agiData, 0);
-            }
             if (InodeBtreeInfo.Magic != AllocationGroupInodeBtreeInfo.AgiMagic)
             {
                 throw new IOException("Invalid AGI magic - probably not an xfs file system");

--- a/Library/DiscUtils.Xfs/AllocationGroupFreeBlockInfo.cs
+++ b/Library/DiscUtils.Xfs/AllocationGroupFreeBlockInfo.cs
@@ -108,9 +108,23 @@ namespace DiscUtils.Xfs
         /// </summary>
         public BtreeHeader FreeSpaceCount { get; private set; }
 
-        public int Size
+        public Guid UniqueId { get; private set; }
+
+        public ulong Lsn { get; private set; }
+
+        public uint Crc { get; private set; }
+
+        public int Size { get; private set; }
+
+        public int InitSize(uint sbversion)
         {
-            get { return 0x40; }
+            if (sbversion >= 5)
+            {
+                Size = 0x5C;
+                return 0x5C;
+            }
+            Size = 0x40;
+            return 0x40;
         }
 
         public int ReadFrom(byte[] buffer, int offset)
@@ -133,6 +147,14 @@ namespace DiscUtils.Xfs
             FreeBlocks = Utilities.ToUInt32BigEndian(buffer, offset + 0x34);
             Longest = Utilities.ToUInt32BigEndian(buffer, offset + 0x38);
             BTreeBlocks = Utilities.ToUInt32BigEndian(buffer, offset + 0x3C);
+            return Size;
+        }
+
+        public int ReadFromVersion5(byte[] buffer, int offset)
+        {
+            UniqueId = Utilities.ToGuidBigEndian(buffer, offset + 0x40);
+            Lsn = Utilities.ToUInt64BigEndian(buffer, offset + 0x50);
+            Crc = Utilities.ToUInt32BigEndian(buffer, offset + 0x58);
             return Size;
         }
 

--- a/Library/DiscUtils.Xfs/AllocationGroupFreeBlockInfo.cs
+++ b/Library/DiscUtils.Xfs/AllocationGroupFreeBlockInfo.cs
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2016, Bianco Veigel
+// Copyright (c) 2017, Timo Walter
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -110,21 +111,21 @@ namespace DiscUtils.Xfs
 
         public Guid UniqueId { get; private set; }
 
+        /// <summary>
+        /// last write sequence
+        /// </summary>
         public ulong Lsn { get; private set; }
 
         public uint Crc { get; private set; }
 
-        public int Size { get; private set; }
+        public int Size { get; }
 
-        public int InitSize(uint sbversion)
+        private uint SbVersion { get; }
+
+        public AllocationGroupFreeBlockInfo(SuperBlock superBlock)
         {
-            if (sbversion >= 5)
-            {
-                Size = 0x5C;
-                return 0x5C;
-            }
-            Size = 0x40;
-            return 0x40;
+            SbVersion = superBlock.SbVersion;
+            Size = SbVersion >= 5 ? 92 : 64;
         }
 
         public int ReadFrom(byte[] buffer, int offset)
@@ -147,14 +148,12 @@ namespace DiscUtils.Xfs
             FreeBlocks = Utilities.ToUInt32BigEndian(buffer, offset + 0x34);
             Longest = Utilities.ToUInt32BigEndian(buffer, offset + 0x38);
             BTreeBlocks = Utilities.ToUInt32BigEndian(buffer, offset + 0x3C);
-            return Size;
-        }
-
-        public int ReadFromVersion5(byte[] buffer, int offset)
-        {
-            UniqueId = Utilities.ToGuidBigEndian(buffer, offset + 0x40);
-            Lsn = Utilities.ToUInt64BigEndian(buffer, offset + 0x50);
-            Crc = Utilities.ToUInt32BigEndian(buffer, offset + 0x58);
+            if (SbVersion >= 5)
+            {
+                UniqueId = Utilities.ToGuidBigEndian(buffer, offset + 0x40);
+                Lsn = Utilities.ToUInt64BigEndian(buffer, offset + 0x50);
+                Crc = Utilities.ToUInt32BigEndian(buffer, offset + 0x58);
+            }
             return Size;
         }
 

--- a/Library/DiscUtils.Xfs/BTreeExtentLeaf.cs
+++ b/Library/DiscUtils.Xfs/BTreeExtentLeaf.cs
@@ -26,7 +26,7 @@ namespace DiscUtils.Xfs
     using System.Collections.Generic;
     using System.IO;
 
-    internal class BTreeExtentLeave : BTreeExtentHeader
+    internal class BTreeExtentLeaf : BTreeExtentHeader
     {
         public Extent[] Extents { get; private set; }
 

--- a/Library/DiscUtils.Xfs/BTreeExtentNode.cs
+++ b/Library/DiscUtils.Xfs/BTreeExtentNode.cs
@@ -67,7 +67,7 @@ namespace DiscUtils.Xfs
                 BTreeExtentHeader child;
                 if (Level == 1)
                 {
-                    child = new BTreeExtentLeave();
+                    child = new BTreeExtentLeaf();
                 }
                 else
                 {

--- a/Library/DiscUtils.Xfs/BTreeExtentRoot.cs
+++ b/Library/DiscUtils.Xfs/BTreeExtentRoot.cs
@@ -79,7 +79,7 @@ namespace DiscUtils.Xfs
                 BTreeExtentHeader child;
                 if (Level == 1)
                 {
-                    child = new BTreeExtentLeave();
+                    child = new BTreeExtentLeaf();
                 }
                 else
                 {

--- a/Library/DiscUtils.Xfs/BTreeHeader.cs
+++ b/Library/DiscUtils.Xfs/BTreeHeader.cs
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2016, Bianco Veigel
+// Copyright (c) 2017, Timo Walter
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -37,8 +38,14 @@ namespace DiscUtils.Xfs
 
         public int RightSibling { get; private set; }
 
+        /// <summary>
+        /// location on disk
+        /// </summary>
         public ulong Bno { get; private set; }
 
+        /// <summary>
+        /// last write sequence
+        /// </summary>
         public ulong Lsn { get; private set; }
 
         public Guid UniqueId { get; private set; }
@@ -47,17 +54,14 @@ namespace DiscUtils.Xfs
 
         public uint Crc { get; private set; }
 
-        public virtual int Size { get; private set; }
+        public virtual int Size { get; }
 
-        public int InitSize(uint sbVersion)
+        protected uint SbVersion { get; }
+
+        public BtreeHeader(uint superBlockVersion)
         {
-            if (sbVersion >= 5)
-            {
-                Size = 0x38;
-                return 0x38;
-            }
-            Size = 0x1;
-            return 0x1;
+            SbVersion = superBlockVersion;
+            Size = SbVersion >= 5 ? 56 : 16;
         }
 
         public virtual int ReadFrom(byte[] buffer, int offset)
@@ -67,16 +71,14 @@ namespace DiscUtils.Xfs
             NumberOfRecords = Utilities.ToUInt16BigEndian(buffer, offset + 0x6);
             LeftSibling = Utilities.ToInt32BigEndian(buffer, offset + 0x8);
             RightSibling = Utilities.ToInt32BigEndian(buffer, offset + 0xC);
-            return Size;
-        }
-
-        public int ReadFromVersion5(byte[] buffer, int offset)
-        {
-            Bno = Utilities.ToUInt64BigEndian(buffer, offset + 0x10);
-            Lsn = Utilities.ToUInt64BigEndian(buffer, offset + 0x18);
-            UniqueId = Utilities.ToGuidBigEndian(buffer, offset + 0x20);
-            Owner = Utilities.ToUInt32BigEndian(buffer, offset + 0x30);
-            Crc = Utilities.ToUInt32BigEndian(buffer, offset + 0x34);
+            if (SbVersion >= 5)
+            {
+                Bno = Utilities.ToUInt64BigEndian(buffer, offset + 0x10);
+                Lsn = Utilities.ToUInt64BigEndian(buffer, offset + 0x18);
+                UniqueId = Utilities.ToGuidBigEndian(buffer, offset + 0x20);
+                Owner = Utilities.ToUInt32BigEndian(buffer, offset + 0x30);
+                Crc = Utilities.ToUInt32BigEndian(buffer, offset + 0x34);
+            }
             return Size;
         }
 

--- a/Library/DiscUtils.Xfs/BTreeHeader.cs
+++ b/Library/DiscUtils.Xfs/BTreeHeader.cs
@@ -37,9 +37,27 @@ namespace DiscUtils.Xfs
 
         public int RightSibling { get; private set; }
 
-        public virtual int Size
+        public ulong Bno { get; private set; }
+
+        public ulong Lsn { get; private set; }
+
+        public Guid UniqueId { get; private set; }
+
+        public uint Owner { get; private set; }
+
+        public uint Crc { get; private set; }
+
+        public virtual int Size { get; private set; }
+
+        public int InitSize(uint sbVersion)
         {
-            get { return 16; }
+            if (sbVersion >= 5)
+            {
+                Size = 0x38;
+                return 0x38;
+            }
+            Size = 0x1;
+            return 0x1;
         }
 
         public virtual int ReadFrom(byte[] buffer, int offset)
@@ -49,7 +67,17 @@ namespace DiscUtils.Xfs
             NumberOfRecords = Utilities.ToUInt16BigEndian(buffer, offset + 0x6);
             LeftSibling = Utilities.ToInt32BigEndian(buffer, offset + 0x8);
             RightSibling = Utilities.ToInt32BigEndian(buffer, offset + 0xC);
-            return 16;
+            return Size;
+        }
+
+        public int ReadFromVersion5(byte[] buffer, int offset)
+        {
+            Bno = Utilities.ToUInt64BigEndian(buffer, offset + 0x10);
+            Lsn = Utilities.ToUInt64BigEndian(buffer, offset + 0x18);
+            UniqueId = Utilities.ToGuidBigEndian(buffer, offset + 0x20);
+            Owner = Utilities.ToUInt32BigEndian(buffer, offset + 0x30);
+            Crc = Utilities.ToUInt32BigEndian(buffer, offset + 0x34);
+            return Size;
         }
 
         public virtual void WriteTo(byte[] buffer, int offset)

--- a/Library/DiscUtils.Xfs/BTreeInodeLeaf.cs
+++ b/Library/DiscUtils.Xfs/BTreeInodeLeaf.cs
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2016, Bianco Veigel
+// Copyright (c) 2017, Timo Walter
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -26,7 +27,7 @@ namespace DiscUtils.Xfs
 {
     using System;
 
-    internal class BTreeInodeLeave : BtreeHeader
+    internal class BTreeInodeLeaf : BtreeHeader
     {
         public BTreeInodeRecord[] Records { get; private set; }
         public override int Size
@@ -34,13 +35,11 @@ namespace DiscUtils.Xfs
             get { return base.Size + (NumberOfRecords * 0x10); }
         }
 
+        public BTreeInodeLeaf(uint superBlockVersion) : base(superBlockVersion){}
+
         public override int ReadFrom(byte[] buffer, int offset)
         {
             base.ReadFrom(buffer, offset);
-            if (base.Size == 0x38)
-            {
-                ReadFromVersion5(buffer, offset);
-            }
             offset += base.Size;
             if (Level != 0)
                 throw new IOException("invalid B+tree level - expected 1");

--- a/Library/DiscUtils.Xfs/BTreeInodeLeave.cs
+++ b/Library/DiscUtils.Xfs/BTreeInodeLeave.cs
@@ -36,7 +36,12 @@ namespace DiscUtils.Xfs
 
         public override int ReadFrom(byte[] buffer, int offset)
         {
-            offset += base.ReadFrom(buffer, offset);
+            base.ReadFrom(buffer, offset);
+            if (base.Size == 0x38)
+            {
+                ReadFromVersion5(buffer, offset);
+            }
+            offset += base.Size;
             if (Level != 0)
                 throw new IOException("invalid B+tree level - expected 1");
             Records = new BTreeInodeRecord[NumberOfRecords];

--- a/Library/DiscUtils.Xfs/BTreeInodeNode.cs
+++ b/Library/DiscUtils.Xfs/BTreeInodeNode.cs
@@ -43,7 +43,12 @@ namespace DiscUtils.Xfs
 
         public override int ReadFrom(byte[] buffer, int offset)
         {
-            offset += base.ReadFrom(buffer, offset);
+            base.ReadFrom(buffer, offset);
+            if (base.Size == 0x38)
+            {
+                ReadFromVersion5(buffer, offset);
+            }
+            offset += base.Size;
             if (Level == 0)
                 throw new IOException("invalid B+tree level - expected 0");
             Keys = new uint[NumberOfRecords];
@@ -76,6 +81,7 @@ namespace DiscUtils.Xfs
                 var data = ag.Context.RawStream;
                 data.Position = (Pointer[i] * ag.Context.SuperBlock.Blocksize) + ag.Offset;
                 var buffer = Utilities.ReadFully(data, (int)ag.Context.SuperBlock.Blocksize);
+                child.InitSize(ag.Context.SuperBlock.SbVersion);
                 child.ReadFrom(buffer, 0);
                 child.LoadBtree(ag);
                 Children.Add(Keys[i], child);

--- a/Library/DiscUtils.Xfs/Directory.cs
+++ b/Library/DiscUtils.Xfs/Directory.cs
@@ -95,12 +95,15 @@ namespace DiscUtils.Xfs
             {
                 if (extent.StartOffset < leafOffset)
                 {
-                    var leafDir = new LeafDirectory();
-                    var buffer = extent.GetData(Context, Context.SuperBlock.DirBlockSize);
-                    leafDir.ReadFrom(buffer, 0);
-                    if (leafDir.Magic != LeafDirectory.HeaderMagic)
-                        throw new IOException("invalid leaf directory magic");
-                    AddDirEntries(leafDir.Entries, target);
+                    for (int i = 0; i < extent.BlockCount; i++)
+                    {
+                        var buffer = extent.GetData(Context, i* Context.SuperBlock.DirBlockSize, Context.SuperBlock.DirBlockSize);
+                        var leafDir = new LeafDirectory();
+                        leafDir.ReadFrom(buffer, 0);
+                        if (leafDir.Magic != LeafDirectory.HeaderMagic)
+                            throw new IOException("invalid leaf directory magic");
+                        AddDirEntries(leafDir.Entries, target);
+                    }
 
                 }
             }

--- a/Library/DiscUtils.Xfs/Extent.cs
+++ b/Library/DiscUtils.Xfs/Extent.cs
@@ -74,12 +74,12 @@ namespace DiscUtils.Xfs
 
         public byte[] GetData(Context context)
         {
-            return GetData(context, context.SuperBlock.Blocksize*BlockCount);
+            return GetData(context,0 , context.SuperBlock.Blocksize*BlockCount);
         }
 
-        public byte[] GetData(Context context, uint count)
+        public byte[] GetData(Context context, long offset, uint count)
         {
-            context.RawStream.Position = GetOffset(context);
+            context.RawStream.Position = GetOffset(context) + offset;
             return Utilities.ReadFully(context.RawStream, (int) count);
         }
 

--- a/Library/DiscUtils.Xfs/SuperBlock.cs
+++ b/Library/DiscUtils.Xfs/SuperBlock.cs
@@ -1,6 +1,7 @@
 //
 // Copyright (c) 2008-2011, Kenneth Bell
 // Copyright (c) 2016, Bianco Veigel
+// Copyright (c) 2017, Timo Walter
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -396,27 +397,25 @@ namespace DiscUtils.Xfs
             LogUnitSize = Utilities.ToUInt32BigEndian(buffer, offset + 0xC4);
             Features2 = Utilities.ToUInt32BigEndian(buffer, offset + 0xC8);
             BadFeatures2 = Utilities.ToUInt32BigEndian(buffer, offset + 0xCC);
-            return 208;
-        }
+            if (SbVersion >= XfsSbVersion5)
+            {
+                CompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset);
+                ReadOnlyCompatibleFeatures = (ReadOnlyCompatibleFeatures)Utilities.ToUInt32BigEndian(buffer, offset + 0x04);
+                IncompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset + 0x08);
+                LogIncompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset + 0x0C);
+                Crc = Utilities.ToUInt32BigEndian(buffer, offset + 0x10);
+                SparseInodeAlignment = Utilities.ToUInt32BigEndian(buffer, offset + 0x14);
+                ProjectQuotaInode = Utilities.ToUInt64BigEndian(buffer, offset + 0x18);
+                Lsn = Utilities.ToInt64BigEndian(buffer, offset + 0x20);
+                MetaUuid = Utilities.ToGuidBigEndian(buffer, offset + 0x28);
 
-        public int ReadFromVersion5(byte[] buffer, int offset)
-        {
-            CompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset);
-            ReadOnlyCompatibleFeatures = (ReadOnlyCompatibleFeatures)Utilities.ToUInt32BigEndian(buffer, offset + 0x04);
-            IncompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset + 0x08);
-            LogIncompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset + 0x0C);
-            Crc = Utilities.ToUInt32BigEndian(buffer, offset + 0x10);
-            SparseInodeAlignment = Utilities.ToUInt32BigEndian(buffer, offset + 0x14);
-            ProjectQuotaInode = Utilities.ToUInt64BigEndian(buffer, offset + 0x18);
-            Lsn = Utilities.ToInt64BigEndian(buffer, offset + 0x20);
-            MetaUuid = Utilities.ToGuidBigEndian(buffer, offset + 0x28);
+                var agOffset = AgBlocksLog2 + InodesPerBlockLog2;
+                RelativeInodeMask = 0xffffffff >> (32 - agOffset);
+                AgInodeMask = ~RelativeInodeMask;
 
-            var agOffset = AgBlocksLog2 + InodesPerBlockLog2;
-            RelativeInodeMask = 0xffffffff >> (32-agOffset);
-            AgInodeMask = ~RelativeInodeMask;
-
-            DirBlockSize = Blocksize << DirBlockLog2;
-            return 56;
+                DirBlockSize = Blocksize << DirBlockLog2;
+            }
+            return Size;
         }
 
         public void WriteTo(byte[] buffer, int offset)

--- a/Library/DiscUtils.Xfs/SuperBlock.cs
+++ b/Library/DiscUtils.Xfs/SuperBlock.cs
@@ -408,13 +408,12 @@ namespace DiscUtils.Xfs
                 ProjectQuotaInode = Utilities.ToUInt64BigEndian(buffer, offset + 0x18);
                 Lsn = Utilities.ToInt64BigEndian(buffer, offset + 0x20);
                 MetaUuid = Utilities.ToGuidBigEndian(buffer, offset + 0x28);
-
-                var agOffset = AgBlocksLog2 + InodesPerBlockLog2;
-                RelativeInodeMask = 0xffffffff >> (32 - agOffset);
-                AgInodeMask = ~RelativeInodeMask;
-
-                DirBlockSize = Blocksize << DirBlockLog2;
             }
+            var agOffset = AgBlocksLog2 + InodesPerBlockLog2;
+            RelativeInodeMask = 0xffffffff >> (32 - agOffset);
+            AgInodeMask = ~RelativeInodeMask;
+
+            DirBlockSize = Blocksize << DirBlockLog2;
             return Size;
         }
 

--- a/Library/DiscUtils.Xfs/SuperBlock.cs
+++ b/Library/DiscUtils.Xfs/SuperBlock.cs
@@ -29,6 +29,11 @@ namespace DiscUtils.Xfs
     internal class SuperBlock : IByteArraySerializable
     {
         public const uint XfsMagic = 0x58465342;
+
+        public const uint XfsSbVersionNumbits = 0x000f;
+
+        public const uint XfsSbVersion5 = 5;
+
         /// <summary>
         /// magic number == XFS_SB_MAGIC
         /// </summary>
@@ -328,7 +333,19 @@ namespace DiscUtils.Xfs
 
         public int Size
         {
-            get { return 264; }
+            get
+            {
+                if (SbVersion >= XfsSbVersion5)
+                {
+                    return 264;
+                }
+                return 208;
+            }
+        }
+
+        public uint SbVersion
+        {
+            get { return Version & XfsSbVersionNumbits; }
         }
 
         public int ReadFrom(byte[] buffer, int offset)
@@ -379,22 +396,27 @@ namespace DiscUtils.Xfs
             LogUnitSize = Utilities.ToUInt32BigEndian(buffer, offset + 0xC4);
             Features2 = Utilities.ToUInt32BigEndian(buffer, offset + 0xC8);
             BadFeatures2 = Utilities.ToUInt32BigEndian(buffer, offset + 0xCC);
-            CompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset + 0xD0);
-            ReadOnlyCompatibleFeatures = (ReadOnlyCompatibleFeatures)Utilities.ToUInt32BigEndian(buffer, offset + 0xD4);
-            IncompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset + 0xD8);
-            LogIncompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset + 0xDC);
-            Crc = Utilities.ToUInt32BigEndian(buffer, offset + 0xE0);
-            SparseInodeAlignment = Utilities.ToUInt32BigEndian(buffer, offset + 0xE4);
-            ProjectQuotaInode = Utilities.ToUInt64BigEndian(buffer, offset + 0xE8);
-            Lsn = Utilities.ToInt64BigEndian(buffer, offset + 0xF0);
-            MetaUuid = Utilities.ToGuidBigEndian(buffer, offset + 0xF8);
+            return 208;
+        }
+
+        public int ReadFromVersion5(byte[] buffer, int offset)
+        {
+            CompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset);
+            ReadOnlyCompatibleFeatures = (ReadOnlyCompatibleFeatures)Utilities.ToUInt32BigEndian(buffer, offset + 0x04);
+            IncompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset + 0x08);
+            LogIncompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset + 0x0C);
+            Crc = Utilities.ToUInt32BigEndian(buffer, offset + 0x10);
+            SparseInodeAlignment = Utilities.ToUInt32BigEndian(buffer, offset + 0x14);
+            ProjectQuotaInode = Utilities.ToUInt64BigEndian(buffer, offset + 0x18);
+            Lsn = Utilities.ToInt64BigEndian(buffer, offset + 0x20);
+            MetaUuid = Utilities.ToGuidBigEndian(buffer, offset + 0x28);
 
             var agOffset = AgBlocksLog2 + InodesPerBlockLog2;
             RelativeInodeMask = 0xffffffff >> (32-agOffset);
             AgInodeMask = ~RelativeInodeMask;
 
             DirBlockSize = Blocksize << DirBlockLog2;
-            return 264;
+            return 56;
         }
 
         public void WriteTo(byte[] buffer, int offset)

--- a/Library/DiscUtils.Xfs/VfsXfsFileSystem.cs
+++ b/Library/DiscUtils.Xfs/VfsXfsFileSystem.cs
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2016, Bianco Veigel
+// Copyright (c) 2017, Timo Walter
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -37,15 +38,10 @@ namespace DiscUtils.Xfs
             :base(new XfsFileSystemOptions(parameters))
         {
             stream.Position = 0;
-            byte[] superblockData = Utilities.ReadFully(stream, 208);
+            byte[] superblockData = Utilities.ReadFully(stream, 264);
 
             SuperBlock superblock = new SuperBlock();
             superblock.ReadFrom(superblockData, 0);
-            if (superblock.SbVersion >= 5)
-            {
-                superblockData = Utilities.ReadFully(stream, 56);
-                superblock.ReadFromVersion5(superblockData, 0);
-            }
 
             if (superblock.Magic != SuperBlock.XfsMagic)
             {
@@ -65,7 +61,7 @@ namespace DiscUtils.Xfs
             {
                 var ag = new AllocationGroup(Context, offset);
                 allocationGroups[ag.InodeBtreeInfo.SequenceNumber] = ag;
-                offset = (XFS_AG_DADDR(Context.SuperBlock, i+1, XFS_AGF_DADDR(Context.SuperBlock)) << BBSHIFT) - 4096;
+                offset = (XFS_AG_DADDR(Context.SuperBlock, i+1, XFS_AGF_DADDR(Context.SuperBlock)) << BBSHIFT) - superblock.SectorSize;
             }
             Context.AllocationGroups = allocationGroups;
 

--- a/Library/DiscUtils.Xfs/VfsXfsFileSystem.cs
+++ b/Library/DiscUtils.Xfs/VfsXfsFileSystem.cs
@@ -31,14 +31,21 @@ namespace DiscUtils.Xfs
     {
         private static readonly int XFS_ALLOC_AGFL_RESERVE = 4;
 
+        private static readonly int BBSHIFT = 9;
+
         public VfsXfsFileSystem(Stream stream, FileSystemParameters parameters)
             :base(new XfsFileSystemOptions(parameters))
         {
             stream.Position = 0;
-            byte[] superblockData = Utilities.ReadFully(stream, 264);
+            byte[] superblockData = Utilities.ReadFully(stream, 208);
 
             SuperBlock superblock = new SuperBlock();
             superblock.ReadFrom(superblockData, 0);
+            if (superblock.SbVersion >= 5)
+            {
+                superblockData = Utilities.ReadFully(stream, 56);
+                superblock.ReadFromVersion5(superblockData, 0);
+            }
 
             if (superblock.Magic != SuperBlock.XfsMagic)
             {
@@ -58,7 +65,7 @@ namespace DiscUtils.Xfs
             {
                 var ag = new AllocationGroup(Context, offset);
                 allocationGroups[ag.InodeBtreeInfo.SequenceNumber] = ag;
-                offset += ag.FreeBlockInfo.Length*superblock.Blocksize;
+                offset = (XFS_AG_DADDR(Context.SuperBlock, i+1, XFS_AGF_DADDR(Context.SuperBlock)) << BBSHIFT) - 4096;
             }
             Context.AllocationGroups = allocationGroups;
 
@@ -150,5 +157,36 @@ namespace DiscUtils.Xfs
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// https://github.com/torvalds/linux/blob/2a610b8aa8e5bd449ba270e517b0e72295d62c9c/fs/xfs/libxfs/xfs_format.h#L832
+        /// </summary>
+        private long XFS_AG_DADDR(SuperBlock sb, int agno, long d)
+        {
+            return XFS_AGB_TO_DADDR(sb, agno, 0) + d;
+        }
+
+        /// <summary>
+        /// https://github.com/torvalds/linux/blob/2a610b8aa8e5bd449ba270e517b0e72295d62c9c/fs/xfs/libxfs/xfs_format.h#L829
+        /// </summary>
+        private long XFS_AGB_TO_DADDR(SuperBlock sb, int agno, int agbno)
+        {
+            return XFS_FSB_TO_BB(sb, agno * sb.AgBlocks) + agbno;
+        }
+
+        /// <summary>
+        /// https://github.com/torvalds/linux/blob/2a610b8aa8e5bd449ba270e517b0e72295d62c9c/fs/xfs/libxfs/xfs_format.h#L587
+        /// </summary>
+        private long XFS_FSB_TO_BB(SuperBlock sb, long fsbno)
+        {
+            return fsbno << (sb.BlocksizeLog2 - BBSHIFT);
+        }
+
+        /// <summary>
+        /// https://github.com/torvalds/linux/blob/2a610b8aa8e5bd449ba270e517b0e72295d62c9c/fs/xfs/libxfs/xfs_format.h#L716
+        /// </summary>
+        private long XFS_AGF_DADDR(SuperBlock sb)
+        {
+            return 1 << (sb.SectorSizeLog2 - BBSHIFT);
+        }
     }
 }

--- a/Library/DiscUtils/DiscUtils.csproj
+++ b/Library/DiscUtils/DiscUtils.csproj
@@ -43,6 +43,7 @@
     <ProjectReference Include="..\DiscUtils.Vhdx\DiscUtils.Vhdx.csproj" />
     <ProjectReference Include="..\DiscUtils.Vmdk\DiscUtils.Vmdk.csproj" />
     <ProjectReference Include="..\DiscUtils.Wim\DiscUtils.Wim.csproj" />
+    <ProjectReference Include="..\DiscUtils.Xfs\DiscUtils.Xfs.csproj" />
     <ProjectReference Include="..\DiscUtils.Xva\DiscUtils.Xva.csproj" />
   </ItemGroup>
 

--- a/Library/DiscUtils/SetupHelper.cs
+++ b/Library/DiscUtils/SetupHelper.cs
@@ -13,6 +13,7 @@ using DiscUtils.Sdi;
 using DiscUtils.SquashFs;
 using DiscUtils.Udf;
 using DiscUtils.Wim;
+using DiscUtils.Xfs;
 
 #if !NETCORE
 using DiscUtils.Net.Dns;
@@ -50,6 +51,7 @@ namespace DiscUtils.Complete
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(Vhdx.Disk)));
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(Vmdk.Disk)));
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(WimFile)));
+            Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(XfsFileSystem)));
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(Xva.Disk)));
         }
     }

--- a/Tests/LibraryTests/Xfs/Data/xfs.zip
+++ b/Tests/LibraryTests/Xfs/Data/xfs.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73a1e172172b1030b39be9b91e43159f0efbfe5f4a31c45faf2c46113e4bc8cf
+size 787422

--- a/Tests/LibraryTests/Xfs/SampleDataTests.cs
+++ b/Tests/LibraryTests/Xfs/SampleDataTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using DiscUtils;
+using DiscUtils.Complete;
+using DiscUtils.Xfs;
+using DiscUtils.Vhdx;
+using LibraryTests.Utilities;
+using Xunit;
+
+namespace LibraryTests.Xfs
+{
+    public class SampleDataTests
+    {
+        [Fact]
+        public void XfsVhdxZip()
+        {
+            SetupHelper.SetupComplete();
+            using (FileStream fs = File.OpenRead(Path.Combine("..", "..", "..", "Xfs", "Data", "xfs.zip")))
+            using (Stream vhdx = ZipUtilities.ReadFileFromZip(fs))
+            using (var diskImage = new DiskImageFile(vhdx, Ownership.Dispose))
+            using (var disk = new Disk(new List<DiskImageFile> { diskImage }, Ownership.Dispose))
+            {
+                var manager = new VolumeManager(disk);
+                var logicalVolumes = manager.GetLogicalVolumes();
+                Assert.Equal(1, logicalVolumes.Length);
+
+                var volume = logicalVolumes[0];
+                var filesystems = FileSystemManager.DetectFileSystems(volume);
+                Assert.Equal(1, filesystems.Length);
+
+                var filesystem = filesystems[0];
+                Assert.Equal("xfs", filesystem.Name);
+
+                var xfs = filesystem.Open(volume);
+                Assert.IsType<XfsFileSystem>(xfs);
+
+                Assert.Equal(9082019840, xfs.AvailableSpace);
+                Assert.Equal(10725863424, xfs.Size);
+                Assert.Equal(1643843584, xfs.UsedSpace);
+                ValidateContent(xfs);
+            }
+        }
+
+        private void ValidateContent(DiscFileSystem xfs)
+        {
+            Assert.True(xfs.FileExists("folder\\nested\\file"));
+            Assert.Equal(0, xfs.GetFileSystemEntries("empty").Length);
+            for (int i = 1; i <= 1000; i++)
+            {
+                Assert.True(xfs.FileExists($"folder\\file.{i}"), $"File file.{i} not found");
+            }
+
+            using (var file = xfs.OpenFile("folder\\file.100", FileMode.Open))
+            {
+                var md5 = MD5.Create().ComputeHash(file);
+                Assert.Equal("620f0b67a91f7f74151bc5be745b7110", BitConverter.ToString(md5).ToLowerInvariant().Replace("-", string.Empty));
+            }
+
+            using (var file = xfs.OpenFile("folder\\file.random", FileMode.Open))
+            {
+                var md5 = MD5.Create().ComputeHash(file);
+                Assert.Equal("9a202a11d6e87688591eb97714ed56f1", BitConverter.ToString(md5).ToLowerInvariant().Replace("-", string.Empty));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Fixes:
- multiblock directory extents (Extent.BlockCount > 1)
- calculation of AG offsets (mostly copied from kernel)

### Features:
- support for Superblock Version 5 ([Self Describing Metadata](https://www.kernel.org/doc/Documentation/filesystems/xfs-self-describing-metadata.txt))
- unit test