### PR TITLE
Include Lvm2 in DiscUtils.Complete

### DIFF
--- a/Library/DiscUtils.Core/Setup/SetupHelper.cs
+++ b/Library/DiscUtils.Core/Setup/SetupHelper.cs
@@ -32,6 +32,7 @@ namespace DiscUtils.Setup
 
                 FileSystemManager.RegisterFileSystems(assembly);
                 VirtualDiskManager.RegisterVirtualDiskTypes(assembly);
+                VolumeManager.RegisterLogicalVolumeFactory(assembly);
             }
         }
     }

--- a/Library/DiscUtils.Core/VolumeManager.cs
+++ b/Library/DiscUtils.Core/VolumeManager.cs
@@ -51,6 +51,7 @@ namespace DiscUtils
 
         private Dictionary<string, PhysicalVolumeInfo> _physicalVolumes;
         private Dictionary<string, LogicalVolumeInfo> _logicalVolumes;
+        private static readonly Assembly _coreAssembly = ReflectionHelper.GetAssembly(typeof(VolumeManager));
 
         /// <summary>
         /// Initializes a new instance of the VolumeManager class.
@@ -89,7 +90,7 @@ namespace DiscUtils
                 if (s_logicalVolumeFactories == null)
                 {
                     List<LogicalVolumeFactory> factories = new List<LogicalVolumeFactory>();
-                    factories.AddRange(GetLogicalVolumeFactories(ReflectionHelper.GetAssembly(typeof(VolumeManager))));
+                    factories.AddRange(GetLogicalVolumeFactories(_coreAssembly));
                     s_logicalVolumeFactories = factories;
                 }
 
@@ -114,6 +115,7 @@ namespace DiscUtils
         /// <param name="assembly">The assembly to inspect</param>
         public static void RegisterLogicalVolumeFactory(Assembly assembly)
         {
+            if (assembly == _coreAssembly) return;
             LogicalVolumeFactories.AddRange(GetLogicalVolumeFactories(assembly));
         }
 

--- a/Library/DiscUtils/DiscUtils.csproj
+++ b/Library/DiscUtils/DiscUtils.csproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\DiscUtils.HfsPlus\DiscUtils.HfsPlus.csproj" />
     <ProjectReference Include="..\DiscUtils.Iscsi\DiscUtils.Iscsi.csproj" />
     <ProjectReference Include="..\DiscUtils.Iso9660\DiscUtils.Iso9660.csproj" />
+    <ProjectReference Include="..\DiscUtils.Lvm\DiscUtils.Lvm.csproj" />
     <ProjectReference Include="..\DiscUtils.Nfs\DiscUtils.Nfs.csproj" />
     <ProjectReference Include="..\DiscUtils.Ntfs\DiscUtils.Ntfs.csproj" />
     <ProjectReference Include="..\DiscUtils.OpticalDisk\DiscUtils.OpticalDisk.csproj" />

--- a/Library/DiscUtils/SetupHelper.cs
+++ b/Library/DiscUtils/SetupHelper.cs
@@ -51,6 +51,7 @@ namespace DiscUtils.Complete
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(Vmdk.Disk)));
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(WimFile)));
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(Xva.Disk)));
+            Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(Lvm.LogicalVolumeManager)));
         }
     }
 }

--- a/Tests/LibraryTests/Lvm/Data/lvm2.zip
+++ b/Tests/LibraryTests/Lvm/Data/lvm2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed6b99968f74df94b05d3daf965a7045076562e7c98e08dbd1b2017491550a8c
+size 1523373

--- a/Tests/LibraryTests/Lvm/SampleDataTests.cs
+++ b/Tests/LibraryTests/Lvm/SampleDataTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using DiscUtils;
 using DiscUtils.Complete;
 using DiscUtils.Vhdx;

--- a/Tests/LibraryTests/Lvm/SampleDataTests.cs
+++ b/Tests/LibraryTests/Lvm/SampleDataTests.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DiscUtils;
+using DiscUtils.Complete;
+using DiscUtils.Vhdx;
+using LibraryTests.Utilities;
+using Xunit;
+
+namespace LibraryTests.Lvm
+{
+    public class SampleDataTests
+    {
+        [Fact]
+        public void Lvm2VhdxZip()
+        {
+            SetupHelper.SetupComplete();
+            using (FileStream fs = File.OpenRead(Path.Combine("..", "..", "..", "Lvm", "Data", "lvm2.zip")))
+            using (Stream vhdx = ZipUtilities.ReadFileFromZip(fs))
+            using (var diskImage = new DiskImageFile(vhdx, Ownership.Dispose))
+            using (var disk = new Disk(new List<DiskImageFile> { diskImage }, Ownership.Dispose))
+            {
+                var manager = new VolumeManager(disk);
+                var logicalVolumes = manager.GetLogicalVolumes();
+                Assert.Equal(3, logicalVolumes.Length);
+
+                Assert.Equal(1283457024, logicalVolumes[0].Length);
+                Assert.Equal(746586112, logicalVolumes[1].Length);
+                Assert.Equal(1178599424, logicalVolumes[2].Length);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes the registration of the Lvm2 LogicalVolumeManagerFactory.

I've also added a sample file and a unit tests. The sample file contains three (mostly empty) logical volumes with overlapping data ranges.