### PR TITLE
Vhdx log replay

### DIFF
--- a/Library/DiscUtils.Vhdx/DiskImageFile.cs
+++ b/Library/DiscUtils.Vhdx/DiskImageFile.cs
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2008-2012, Kenneth Bell
+// Copyright (c) 2017, Bianco Veigel
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -687,21 +688,29 @@ namespace DiscUtils.Vhdx
                 throw new IOException("Unable to replay VHDX log, suspected corrupt VHDX file");
             }
 
+            if (activeLogSequence.Head.FlushedFileOffset > (ulong)_logicalStream.Length)
+            {
+                throw new IOException("truncated VHDX file found while replaying log");
+            }
+
             if (activeLogSequence.Count > 1 || !activeLogSequence.Head.IsEmpty)
             {
-                // TODO - perform actual replay (needs VHDX with real log to replay)
                 // However, have seen VHDX with a non-empty log with no data to replay.  These are
                 // 'safe' to open.
-                throw new NotImplementedException("Actual replay of VHDX logs not implemented yet");
-
-                //// Have a log to replay, and the base stream is read-only. Use a snapshot stream to
-                //// replay in RAM.
-                ////if (!_fileStream.CanWrite)
-                ////{
-                ////    SnapshotStream replayStream = new SnapshotStream(_fileStream, Ownership.None);
-                ////    replayStream.Snapshot();
-                ////    _logicalStream = replayStream;
-                ////}
+                if (!_fileStream.CanWrite)
+                {
+                    SnapshotStream replayStream = new SnapshotStream(_fileStream, Ownership.None);
+                    replayStream.Snapshot();
+                    _logicalStream = replayStream;
+                }
+                foreach (LogEntry logEntry in activeLogSequence)
+                {
+                    if (logEntry.LogGuid != _header.LogGuid)
+                        throw new IOException("Invalid log entry in VHDX log, suspected currupt VHDX file");
+                    if (logEntry.IsEmpty) continue;
+                    logEntry.Replay(_logicalStream);
+                }
+                _logicalStream.Seek((long)activeLogSequence.Head.LastFileOffset, SeekOrigin.Begin);
             }
         }
 

--- a/Tests/LibraryTests/Vhdx/Data/vhdx-log-replay.zip
+++ b/Tests/LibraryTests/Vhdx/Data/vhdx-log-replay.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fde2aab09788892509f0d338250ad52fdf51d88e95f9bbbbf9e9732dc7d7de5
+size 39945

--- a/Tests/LibraryTests/Vhdx/LogReplayTest.cs
+++ b/Tests/LibraryTests/Vhdx/LogReplayTest.cs
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2017 Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System.Collections.Generic;
+using System.IO;
+using DiscUtils;
+using DiscUtils.Vhdx;
+using LibraryTests.Utilities;
+using Xunit;
+
+namespace LibraryTests.Vhdx
+{
+    public class LogReplayTest
+    {
+        [Fact]
+        public void ReplayLog()
+        {
+            using (FileStream fs = File.OpenRead(Path.Combine("..", "..", "..", "Vhdx", "Data", "vhdx-log-replay.zip")))
+            using (Stream vhdx = ZipUtilities.ReadFileFromZip(fs))
+            using (var diskImage = new DiskImageFile(vhdx, Ownership.Dispose))
+            using (var disk = new Disk(new List<DiskImageFile> { diskImage }, Ownership.Dispose))
+            {
+                Assert.True(disk.IsPartitioned);
+                Assert.Equal(2, disk.Partitions.Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implementation is based on the [Microsoft documentation](https://msdn.microsoft.com/en-us/library/mt740033.aspx).

I've also added a vhdx test file which is empty without a log replay, but contains a valid partition table inside the log.