### PR TITLE
Performance optimization for size info in NTFS

### DIFF
--- a/Library/DiscUtils.Ntfs/Bitmap.cs
+++ b/Library/DiscUtils.Ntfs/Bitmap.cs
@@ -185,7 +185,7 @@ namespace DiscUtils.Ntfs
 
         internal long Size { get { return _bitmap.Length; } }
 
-        public byte GetByte(long index)
+        internal byte GetByte(long index)
         {
             if (index >= _bitmap.Length)
             {
@@ -200,15 +200,15 @@ namespace DiscUtils.Ntfs
             }
             return 0;
         }
-
-        public int GetBytes(byte[] buffer, long index, int count)
+        
+        internal int GetBytes(long index, byte[] buffer, int offset, int count)
         {
             if (index + count >= _bitmap.Length)
                 count = (int)(_bitmap.Length - index);
             if (count <= 0)
                 return 0;
             _bitmap.Position = index;
-            return _bitmap.Read(buffer, 0, count);
+            return _bitmap.Read(buffer, offset, count);
         }
 
         private void SetByte(long index, byte value)

--- a/Library/DiscUtils.Ntfs/Bitmap.cs
+++ b/Library/DiscUtils.Ntfs/Bitmap.cs
@@ -201,6 +201,16 @@ namespace DiscUtils.Ntfs
             return 0;
         }
 
+        public int GetBytes(byte[] buffer, long index, int count)
+        {
+            if (index + count >= _bitmap.Length)
+                count = (int)(_bitmap.Length - index);
+            if (count <= 0)
+                return 0;
+            _bitmap.Position = index;
+            return _bitmap.Read(buffer, 0, count);
+        }
+
         private void SetByte(long index, byte value)
         {
             byte[] buffer = { value };

--- a/Library/DiscUtils.Ntfs/NtfsFileSystem.cs
+++ b/Library/DiscUtils.Ntfs/NtfsFileSystem.cs
@@ -2431,8 +2431,8 @@ namespace DiscUtils.Ntfs
                 while (processed < bitmap.Size)
                 {
                     byte[] buffer = new byte[4*Sizes.OneKiB];
-                    var count = bitmap.GetBytes(buffer, processed, buffer.Length);
-                    usedCluster += BitCounter.Count(buffer,0 , count);
+                    var count = bitmap.GetBytes(processed, buffer, 0, buffer.Length);
+                    usedCluster += BitCounter.Count(buffer, 0, count);
                     processed += count;
                 }
                 return (usedCluster* ClusterSize);

--- a/Library/DiscUtils.Ntfs/NtfsFileSystem.cs
+++ b/Library/DiscUtils.Ntfs/NtfsFileSystem.cs
@@ -2427,14 +2427,13 @@ namespace DiscUtils.Ntfs
             {
                 long usedCluster = 0;
                 var bitmap = _context.ClusterBitmap.Bitmap;
-                for (long i = 0; i<bitmap.Size; i++)
+                var processed = 0L;
+                while (processed < bitmap.Size)
                 {
-                    var value = bitmap.GetByte(i);
-                    while (value != 0)
-                    {
-                        usedCluster++;
-                        value &= (byte) (value - 1);
-                    }
+                    byte[] buffer = new byte[4*Sizes.OneKiB];
+                    var count = bitmap.GetBytes(buffer, processed, buffer.Length);
+                    usedCluster += BitCounter.Count(buffer,0 , count);
+                    processed += count;
                 }
                 return (usedCluster* ClusterSize);
             }

--- a/Library/DiscUtils.Streams/Util/BitCounter.cs
+++ b/Library/DiscUtils.Streams/Util/BitCounter.cs
@@ -20,8 +20,13 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Streams
 {
+    /// <summary>
+    /// Helper to count the number of bits set in a byte or byte[]
+    /// </summary>
     public static class BitCounter
     {
         private static readonly byte[] _lookupTable;
@@ -42,18 +47,29 @@ namespace DiscUtils.Streams
             }
         }
 
+        /// <summary>
+        /// count the number of bits set in <paramref name="value"/>
+        /// </summary>
+        /// <returns>the number of bits set in <paramref name="value"/></returns>
         public static byte Count(byte value)
         {
             return _lookupTable[value];
         }
 
-        public static long Count(byte[] values, int start, int count)
+        /// <summary>
+        /// count the number of bits set in each entry of <paramref name="values"/>
+        /// </summary>
+        /// <param name="values">the <see cref="Array"/> to process</param>
+        /// <param name="offset">the values offset to start from</param>
+        /// <param name="count">the number of bytes to count</param>
+        /// <returns></returns>
+        public static long Count(byte[] values, int offset, int count)
         {
-            var end = start + count;
+            var end = offset + count;
             if (end > values.Length)
-                return 0;
+                throw new ArgumentOutOfRangeException(nameof(count), "can't count after end of values");
             var result = 0L;
-            for (int i = start; i < end; i++)
+            for (int i = offset; i < end; i++)
             {
                 var value = values[i];
                 result += _lookupTable[value];

--- a/Library/DiscUtils.Streams/Util/BitCounter.cs
+++ b/Library/DiscUtils.Streams/Util/BitCounter.cs
@@ -1,0 +1,64 @@
+//
+// Copyright (c) 2017, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Streams
+{
+    public static class BitCounter
+    {
+        private static readonly byte[] _lookupTable;
+
+        static BitCounter()
+        {
+            _lookupTable = new byte[256];
+            for (int i = 0; i < 256; i++)
+            {
+                byte bitCount = 0;
+                var value = i;
+                while (value != 0)
+                {
+                    bitCount++;
+                    value &= (byte)(value - 1);
+                }
+                _lookupTable[i] = bitCount;
+            }
+        }
+
+        public static byte Count(byte value)
+        {
+            return _lookupTable[value];
+        }
+
+        public static long Count(byte[] values, int start, int count)
+        {
+            var end = start + count;
+            if (end > values.Length)
+                return 0;
+            var result = 0L;
+            for (int i = start; i < end; i++)
+            {
+                var value = values[i];
+                result += _lookupTable[value];
+            }
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
I've found a major performance penalty in the space usage calculation of NTFS. Currenty the ClusterBitmap is read byte by byte from the underlying disk. This result in runtimes of up to one minute for large filesystems (>1TiB fs with a bitmap >50MiB).

I've changed the implementation to read the bitmap in blocks of 4K, which increased the performance by > 99% (in my test from ~1200ms down to ~45ms).

As a second optimization I've added a BitCounter which uses a precalculated lookup table to further speed up the size calculation from ~45ms down to ~15ms.
