### PR TITLE
XFS Symlink Target NULL Terminator

### DIFF
--- a/Library/DiscUtils.Xfs/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Xfs/Properties/AssemblyInfo.cs
@@ -1,0 +1,24 @@
+﻿//
+// Copyright (c) 2017, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("LibraryTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010047ebec172a9831bb20fede77e17d784026ea7030d7055f2ae09576c71cebe77ebfab436d80580a4fcbba7242ff61bd52b686f5fe9d41fe7cd3e6c05b8a876eccf35b8ad7c5e3a6704295d7210b138d7280a6f72688419a65dd7a8612d66869f2e712c57c41fcc9196e4cb06d95d8e678f6967e65348c370405fb7eeb6aa1d3e8")]

--- a/Library/DiscUtils.Xfs/Symlink.cs
+++ b/Library/DiscUtils.Xfs/Symlink.cs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, Bianco Veigel
+// Copyright (c) 2016-2017, Bianco Veigel
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -44,7 +44,9 @@ namespace DiscUtils.Xfs
                 }
                 IBuffer content = FileContent;
                 byte[] data = StreamUtilities.ReadFully(content, 0, (int) content.Capacity);
-                return Context.Options.FileNameEncoding.GetString(data, 0, data.Length).Replace('/', '\\');
+                var result = Context.Options.FileNameEncoding.GetString(data, 0, data.Length).Replace('/', '\\').TrimEnd('\0');
+                var parts = result.Split('\0');
+                return parts[0];
             }
         }
     }

--- a/Library/DiscUtils.Xfs/Symlink.cs
+++ b/Library/DiscUtils.Xfs/Symlink.cs
@@ -43,10 +43,8 @@ namespace DiscUtils.Xfs
                     throw new IOException("invalid Inode format for symlink");
                 }
                 IBuffer content = FileContent;
-                byte[] data = StreamUtilities.ReadFully(content, 0, (int) content.Capacity);
-                var result = Context.Options.FileNameEncoding.GetString(data, 0, data.Length).Replace('/', '\\').TrimEnd('\0');
-                var parts = result.Split('\0');
-                return parts[0];
+                byte[] data = StreamUtilities.ReadFully(content, 0, (int)Inode.Length);
+                return Context.Options.FileNameEncoding.GetString(data, 0, data.Length).Replace('/', '\\');
             }
         }
     }

--- a/Tests/LibraryTests/LibraryTests.csproj
+++ b/Tests/LibraryTests/LibraryTests.csproj
@@ -10,6 +10,9 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <PublicSign>true</PublicSign>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>../../SigningKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/LibraryTests/Xfs/SampleDataTests.cs
+++ b/Tests/LibraryTests/Xfs/SampleDataTests.cs
@@ -9,6 +9,7 @@ using DiscUtils.Xfs;
 using DiscUtils.Vhdx;
 using LibraryTests.Utilities;
 using Xunit;
+using File=System.IO.File;
 
 namespace LibraryTests.Xfs
 {

--- a/Tests/LibraryTests/Xfs/XfsTests.cs
+++ b/Tests/LibraryTests/Xfs/XfsTests.cs
@@ -36,6 +36,7 @@ namespace LibraryTests.Xfs
         {
             var inodeBuffer = new byte[0x70];
             inodeBuffer[0x5] = (byte)InodeFormat.Local;
+            inodeBuffer[0x3F] = 6;//Length (di_size)
             inodeBuffer[0x52] = 14;//Forkoff
             inodeBuffer[0X64] = (byte)'i';
             inodeBuffer[0X65] = (byte)'n';

--- a/Tests/LibraryTests/Xfs/XfsTests.cs
+++ b/Tests/LibraryTests/Xfs/XfsTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Text;
+using DiscUtils.Xfs;
+using Xunit;
+
+namespace LibraryTests.Xfs
+{
+    public class XfsTests
+    {
+        [Fact]
+        public void CanReadSymlink()
+        {
+            var context = new Context
+            {
+                SuperBlock = new SuperBlock(),
+                Options = new XfsFileSystemOptions { FileNameEncoding = Encoding.UTF8}
+            };
+
+            var inode = new Inode(1, context);
+            inode.ReadFrom(GetInodeBuffer(), 0);
+
+            var symlink = new Symlink(context, inode);
+            Assert.Equal("init.d", symlink.TargetPath);
+
+
+            inode = new Inode(1, context);
+            var inodeBuffer = GetInodeBuffer();
+            inodeBuffer[0x6C] = 60; //garbage after first null byte
+            inode.ReadFrom(inodeBuffer, 0);
+
+            symlink = new Symlink(context, inode);
+            Assert.Equal("init.d", symlink.TargetPath);
+        }
+
+        private byte[] GetInodeBuffer()
+        {
+            var inodeBuffer = new byte[0x70];
+            inodeBuffer[0x5] = (byte)InodeFormat.Local;
+            inodeBuffer[0x52] = 14;//Forkoff
+            inodeBuffer[0X64] = (byte)'i';
+            inodeBuffer[0X65] = (byte)'n';
+            inodeBuffer[0X66] = (byte)'i';
+            inodeBuffer[0X67] = (byte)'t';
+            inodeBuffer[0X68] = (byte)'.';
+            inodeBuffer[0X69] = (byte)'d';
+
+            return inodeBuffer;
+        }
+    }
+}


### PR DESCRIPTION
Fixes the resolution of symlinks - previously the NULL terminator was ignored, resulting in the symlink not beeing resolved.