### PR TITLE
fix LVM2 creation_time > DateTime.MaxValue

### DIFF
--- a/Library/DiscUtils.Lvm/Metadata.cs
+++ b/Library/DiscUtils.Lvm/Metadata.cs
@@ -34,6 +34,7 @@ namespace DiscUtils.Lvm
         public string Contents;
         public int Version;
         public MetadataVolumeGroupSection[] VolumeGroupSections;
+        private static readonly double _maxSeconds = DateTime.MaxValue.Subtract(DateTimeOffsetExtensions.UnixEpoch).TotalSeconds;
 
         public static Metadata Parse(string metadata)
         {
@@ -112,8 +113,11 @@ namespace DiscUtils.Lvm
         internal static DateTime ParseDateTimeValue(string value)
         {
             var numeric = ParseNumericValue(value);
-            return new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddSeconds(numeric);
+            if (numeric > _maxSeconds)
+                return DateTime.MaxValue;
+            return DateTimeOffsetExtensions.UnixEpoch.AddSeconds(numeric);
         }
+
         internal static ulong ParseNumericValue(string value)
         {
             return UInt64.Parse(value.Trim());


### PR DESCRIPTION
The BitDefender GravityZone Virtual Disk contains an LVM2 which has an invalid creation time. This PR adds a check against DateTime.MaxValue to prevent an exception for this case.
```
swap { ...
creation_time = 13815016539583152127
} 
root { ...
creation_time = 9268243417079996778
} ...
# Generated by LVM2 version 2.02.145(2) (2016-03-04): Tue Mar 15 10:18:18 2016
...
creation_host = "rescuecd"	# Linux rescuecd 4.4.5-gentoo-x86 #1 SMP Fri Mar 11 13:59:43 UTC 2016 i686
...
```