### PR TITLE
fix offset calculation for xfs

### DIFF
--- a/Library/DiscUtils.Xfs/AllocationGroup.cs
+++ b/Library/DiscUtils.Xfs/AllocationGroup.cs
@@ -79,7 +79,7 @@ namespace DiscUtils.Xfs
 
         public void LoadInode(Inode inode)
         {
-            var offset = Offset + (inode.AgBlock*Context.SuperBlock.Blocksize) + (inode.BlockOffset * Context.SuperBlock.InodeSize);
+            var offset = Offset + ((long)inode.AgBlock*Context.SuperBlock.Blocksize) + ((long)inode.BlockOffset * Context.SuperBlock.InodeSize);
             Context.RawStream.Position = offset;
             var data = StreamUtilities.ReadFully(Context.RawStream, (int) Context.SuperBlock.InodeSize);
             inode.ReadFrom(data, 0);

--- a/Library/DiscUtils.Xfs/AllocationGroupInodeBtreeInfo.cs
+++ b/Library/DiscUtils.Xfs/AllocationGroupInodeBtreeInfo.cs
@@ -140,7 +140,7 @@ namespace DiscUtils.Xfs
         public void LoadBtree(Context context, long offset)
         {
             var data = context.RawStream;
-            data.Position = offset + context.SuperBlock.Blocksize*Root;
+            data.Position = offset + context.SuperBlock.Blocksize*(long)Root;
             if (Level == 1)
             {
                 RootInodeBtree = new BTreeInodeLeaf(SbVersion);

--- a/Library/DiscUtils.Xfs/BTreeInodeNode.cs
+++ b/Library/DiscUtils.Xfs/BTreeInodeNode.cs
@@ -78,7 +78,7 @@ namespace DiscUtils.Xfs
                     child = new BTreeInodeNode(base.SbVersion);
                 }
                 var data = ag.Context.RawStream;
-                data.Position = (Pointer[i] * ag.Context.SuperBlock.Blocksize) + ag.Offset;
+                data.Position = ((long)Pointer[i] * ag.Context.SuperBlock.Blocksize) + ag.Offset;
                 var buffer = StreamUtilities.ReadFully(data, (int)ag.Context.SuperBlock.Blocksize);
                 child.ReadFrom(buffer, 0);
                 child.LoadBtree(ag);

--- a/Library/DiscUtils.Xfs/Directory.cs
+++ b/Library/DiscUtils.Xfs/Directory.cs
@@ -95,7 +95,7 @@ namespace DiscUtils.Xfs
             {
                 if (extent.StartOffset < leafOffset)
                 {
-                    for (int i = 0; i < extent.BlockCount; i++)
+                    for (long i = 0; i < extent.BlockCount; i++)
                     {
                         var buffer = extent.GetData(Context, i* Context.SuperBlock.DirBlockSize, Context.SuperBlock.DirBlockSize);
                         var leafDir = new LeafDirectory();

--- a/Library/DiscUtils.Xfs/Inode.cs
+++ b/Library/DiscUtils.Xfs/Inode.cs
@@ -309,7 +309,7 @@ namespace DiscUtils.Xfs
             foreach (var extent in extents)
             {
                 var blockOffset = extent.GetOffset(context);
-                var substream = new SubStream(context.RawStream, blockOffset, extent.BlockCount*context.SuperBlock.Blocksize);
+                var substream = new SubStream(context.RawStream, blockOffset, (long)extent.BlockCount*context.SuperBlock.Blocksize);
                 builderExtents.Add(new BuilderSparseStreamExtent((long) extent.StartOffset * context.SuperBlock.Blocksize, substream));
             }
             return new StreamBuffer(new ExtentStream((long) this.Length, builderExtents), Ownership.Dispose);


### PR DESCRIPTION
Currently the calculation from agblock number to byte offset may be incorrect due to Uint32 overflows.
We had an example where the AGI root of the 5th allocation group was `2121031`. This is multiplied by `SuperBlock.Blocksize` to calculate the offset inside the AG. With a Blocksize of 4096 this results in an uint overflow (97808384 instead of 8687742976).