### PR TITLE
Allow interception of File.Open / new FileStream()

### DIFF
--- a/Library/DiscUtils.Core/DiscFileLocator.cs
+++ b/Library/DiscUtils.Core/DiscFileLocator.cs
@@ -42,7 +42,7 @@ namespace DiscUtils
             return _fileSystem.FileExists(Utilities.CombinePaths(_basePath, fileName));
         }
 
-        public override Stream Open(string fileName, FileMode mode, FileAccess access, FileShare share)
+        protected override Stream OpenFile(string fileName, FileMode mode, FileAccess access, FileShare share)
         {
             return _fileSystem.OpenFile(Utilities.CombinePaths(_basePath, fileName), mode, access);
         }

--- a/Library/DiscUtils.Core/FileLocator.cs
+++ b/Library/DiscUtils.Core/FileLocator.cs
@@ -23,6 +23,7 @@
 using System;
 using System.IO;
 using DiscUtils.Internal;
+using DiscUtils.Setup;
 
 namespace DiscUtils
 {
@@ -30,7 +31,16 @@ namespace DiscUtils
     {
         public abstract bool Exists(string fileName);
 
-        public abstract Stream Open(string fileName, FileMode mode, FileAccess access, FileShare share);
+        public Stream Open(string fileName, FileMode mode, FileAccess access, FileShare share)
+        {
+            var args = new FileOpenEventArgs(fileName, mode, access, share, OpenFile);
+            SetupHelper.OnOpeningFile(this, args);
+            if (args.Result != null)
+                return args.Result;
+            return OpenFile(args.FileName, args.FileMode, args.FileAccess, args.FileShare);
+        }
+
+        protected abstract Stream OpenFile(string fileName, FileMode mode, FileAccess access, FileShare share);
 
         public abstract FileLocator GetRelativeLocator(string path);
 

--- a/Library/DiscUtils.Core/Internal/LocalFileLocator.cs
+++ b/Library/DiscUtils.Core/Internal/LocalFileLocator.cs
@@ -39,7 +39,7 @@ namespace DiscUtils.Internal
             return File.Exists(Path.Combine(_dir, fileName));
         }
 
-        public override Stream Open(string fileName, FileMode mode, FileAccess access, FileShare share)
+        protected override Stream OpenFile(string fileName, FileMode mode, FileAccess access, FileShare share)
         {
             return new FileStream(Path.Combine(_dir, fileName), mode, access, share);
         }

--- a/Library/DiscUtils.Core/NativeFileSystem.cs
+++ b/Library/DiscUtils.Core/NativeFileSystem.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.IO;
+using DiscUtils.Internal;
 using DiscUtils.Streams;
 
 namespace DiscUtils
@@ -504,7 +505,8 @@ namespace DiscUtils
                 fileShare = FileShare.Read;
             }
 
-            return SparseStream.FromStream(File.Open(Path.Combine(BasePath, path), mode, access, fileShare),
+            var locator = new LocalFileLocator(BasePath);
+            return SparseStream.FromStream(locator.Open(path, mode, access, fileShare),
                 Ownership.Dispose);
         }
 

--- a/Library/DiscUtils.Core/Raw/Disk.cs
+++ b/Library/DiscUtils.Core/Raw/Disk.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using DiscUtils.Internal;
 using DiscUtils.Streams;
 
 namespace DiscUtils.Raw
@@ -59,10 +60,7 @@ namespace DiscUtils.Raw
         /// </summary>
         /// <param name="path">The path to the disk image.</param>
         public Disk(string path)
-        {
-            _file = new DiskImageFile(new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None),
-                Ownership.Dispose, null);
-        }
+            :this(path, FileAccess.ReadWrite) {}
 
         /// <summary>
         /// Initializes a new instance of the Disk class.
@@ -72,7 +70,8 @@ namespace DiscUtils.Raw
         public Disk(string path, FileAccess access)
         {
             FileShare share = access == FileAccess.Read ? FileShare.Read : FileShare.None;
-            _file = new DiskImageFile(new FileStream(path, FileMode.Open, access, share), Ownership.Dispose, null);
+            var locator = new LocalFileLocator(string.Empty);
+            _file = new DiskImageFile(locator.Open(path, FileMode.Open, access, share), Ownership.Dispose, null);
         }
 
         /// <summary>

--- a/Library/DiscUtils.Core/Setup/FileOpenEventArgs.cs
+++ b/Library/DiscUtils.Core/Setup/FileOpenEventArgs.cs
@@ -1,0 +1,83 @@
+﻿//
+// Copyright (c) 2017, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.IO;
+
+namespace DiscUtils.Setup
+{
+    internal delegate Stream FileOpenDelegate(string fileName, FileMode mode, FileAccess access, FileShare share);
+
+    /// <summary>
+    /// Event arguments for opening a file
+    /// </summary>
+    public class FileOpenEventArgs:EventArgs
+    {
+        private FileOpenDelegate _opener;
+
+        internal FileOpenEventArgs(string fileName, FileMode mode, FileAccess access, FileShare share, FileOpenDelegate opener)
+        {
+            FileName = fileName;
+            FileMode = mode;
+            FileAccess = access;
+            FileShare = share;
+            _opener = opener;
+        }
+
+        /// <summary>
+        /// Gets or sets the filename to open
+        /// </summary>
+        public string FileName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="FileMode"/>
+        /// </summary>
+        public FileMode FileMode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="FileAccess"/>
+        /// </summary>
+        public FileAccess FileAccess { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="FileShare"/>
+        /// </summary>
+        public FileShare FileShare { get; set; }
+
+        /// <summary>
+        /// The resulting stream.
+        /// </summary>
+        /// <remarks>
+        /// If this is set to a non null value, this stream is used instead of opening the supplied <see cref="FileName"/>
+        /// </remarks>
+        public Stream Result { get; set; }
+
+        /// <summary>
+        /// returns the result from the builtin FileLocator
+        /// </summary>
+        /// <returns></returns>
+        public Stream GetFileStream()
+        {
+            return _opener(FileName, FileMode, FileAccess, FileShare);
+        }
+    }
+}

--- a/Library/DiscUtils.Core/Setup/SetupHelper.cs
+++ b/Library/DiscUtils.Core/Setup/SetupHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using DiscUtils.CoreCompat;
 
@@ -34,6 +35,21 @@ namespace DiscUtils.Setup
                 VirtualDiskManager.RegisterVirtualDiskTypes(assembly);
                 VolumeManager.RegisterLogicalVolumeFactory(assembly);
             }
+        }
+
+        /// <summary>
+        /// Allows intercepting any file open operation
+        /// </summary>
+        /// <remarks>
+        /// Can be used to wrap the opened file for special use cases,
+        /// modify the parameters for opening files, validate file names 
+        /// and many more.
+        /// </remarks>
+        public static event EventHandler<FileOpenEventArgs> OpeningFile;
+
+        internal static void OnOpeningFile(object sender, FileOpenEventArgs e)
+        {
+            OpeningFile?.Invoke(sender, e);
         }
     }
 }

--- a/Library/DiscUtils.Dmg/DiskFactory.cs
+++ b/Library/DiscUtils.Dmg/DiskFactory.cs
@@ -53,7 +53,8 @@ namespace DiscUtils.Dmg
 
         public override VirtualDisk OpenDisk(string path, FileAccess access)
         {
-            return new Disk(new FileStream(path, FileMode.Open, access), Ownership.Dispose);
+            var locator = new LocalFileLocator(string.Empty);
+            return OpenDisk(locator, path, access);
         }
 
         public override VirtualDisk OpenDisk(FileLocator locator, string path, FileAccess access)

--- a/Library/DiscUtils.Iso9660/BuildFileInfo.cs
+++ b/Library/DiscUtils.Iso9660/BuildFileInfo.cs
@@ -25,6 +25,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using DiscUtils.CoreCompat;
+using DiscUtils.Internal;
 
 namespace DiscUtils.Iso9660
 {
@@ -82,7 +83,8 @@ namespace DiscUtils.Iso9660
             }
             if (_contentPath != null)
             {
-                return new FileStream(_contentPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                var locator = new LocalFileLocator(string.Empty);
+                return locator.Open(_contentPath, FileMode.Open, FileAccess.Read, FileShare.Read);
             }
             return _contentStream;
         }

--- a/Library/DiscUtils.OpticalDisk/Disc.cs
+++ b/Library/DiscUtils.OpticalDisk/Disc.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using DiscUtils.Internal;
 using DiscUtils.Streams;
 
 namespace DiscUtils.OpticalDisk
@@ -58,10 +59,7 @@ namespace DiscUtils.OpticalDisk
         /// </summary>
         /// <param name="path">The path to the disc image.</param>
         public Disc(string path)
-        {
-            _file = new DiscImageFile(new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None),
-                Ownership.Dispose, OpticalFormat.None);
-        }
+            :this(path, FileAccess.ReadWrite) {}
 
         /// <summary>
         /// Initializes a new instance of the Disc class.
@@ -71,7 +69,8 @@ namespace DiscUtils.OpticalDisk
         public Disc(string path, FileAccess access)
         {
             FileShare share = access == FileAccess.Read ? FileShare.Read : FileShare.None;
-            _file = new DiscImageFile(new FileStream(path, FileMode.Open, access, share), Ownership.Dispose,
+            var locator = new LocalFileLocator(string.Empty);
+            _file = new DiscImageFile(locator.Open(path, FileMode.Open, access, share), Ownership.Dispose,
                 OpticalFormat.None);
         }
 

--- a/Library/DiscUtils.Registry/RegistryHive.cs
+++ b/Library/DiscUtils.Registry/RegistryHive.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.AccessControl;
+using DiscUtils.Internal;
 using DiscUtils.Streams;
 
 namespace DiscUtils.Registry
@@ -188,7 +189,8 @@ namespace DiscUtils.Registry
         /// <returns>The new hive.</returns>
         public static RegistryHive Create(string path)
         {
-            return Create(new FileStream(path, FileMode.Create, FileAccess.ReadWrite), Ownership.Dispose);
+            var locator = new LocalFileLocator(string.Empty);
+            return Create(locator.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None), Ownership.Dispose);
         }
 
         internal K GetCell<K>(int index)

--- a/Library/DiscUtils.SquashFs/BuilderFile.cs
+++ b/Library/DiscUtils.SquashFs/BuilderFile.cs
@@ -22,6 +22,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using DiscUtils.Internal;
 using DiscUtils.Streams;
 
 namespace DiscUtils.SquashFs
@@ -77,7 +78,8 @@ namespace DiscUtils.SquashFs
             {
                 if (_source == null)
                 {
-                    _source = new FileStream(_sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                    var locator = new LocalFileLocator(string.Empty);
+                    _source = locator.Open(_sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read);
                     disposeSource = true;
                 }
 

--- a/Library/DiscUtils.SquashFs/SquashFileSystemBuilder.cs
+++ b/Library/DiscUtils.SquashFs/SquashFileSystemBuilder.cs
@@ -335,7 +335,8 @@ namespace DiscUtils.SquashFs
         /// <param name="outputFile">The file to write to.</param>
         public void Build(string outputFile)
         {
-            using (FileStream destStream = new FileStream(outputFile, FileMode.Create, FileAccess.Write))
+            var locator = new LocalFileLocator(string.Empty);
+            using (Stream destStream = locator.Open(outputFile, FileMode.Create, FileAccess.Write, FileShare.None))
             {
                 Build(destStream);
             }

--- a/Library/DiscUtils.Vdi/Disk.cs
+++ b/Library/DiscUtils.Vdi/Disk.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using DiscUtils.Internal;
 using DiscUtils.Streams;
 
 namespace DiscUtils.Vdi
@@ -41,7 +42,11 @@ namespace DiscUtils.Vdi
         /// <param name="path">The path to the disk.</param>
         /// <param name="access">The access requested to the disk.</param>
         public Disk(string path, FileAccess access)
-            : this(new FileStream(path, FileMode.Open, access), Ownership.Dispose) {}
+        {
+            FileShare share = access == FileAccess.Read ? FileShare.Read : FileShare.None;
+            var locator = new LocalFileLocator(string.Empty);
+            _diskImage = new DiskImageFile(locator.Open(path, FileMode.Open, access, share), Ownership.Dispose);
+        }
 
         /// <summary>
         /// Initializes a new instance of the Disk class.

--- a/Library/DiscUtils.Vmdk/DiskImageFile.cs
+++ b/Library/DiscUtils.Vmdk/DiskImageFile.cs
@@ -69,10 +69,11 @@ namespace DiscUtils.Vmdk
                 fileShare = FileShare.None;
             }
 
-            FileStream fileStream = null;
+            Stream fileStream = null;
+            _fileLocator = new LocalFileLocator(Path.GetDirectoryName(path));
             try
             {
-                fileStream = new FileStream(path, FileMode.Open, fileAccess, fileShare);
+                fileStream = _fileLocator.Open(Path.GetFileName(path), FileMode.Open, fileAccess, fileShare);
                 LoadDescriptor(fileStream);
 
                 // For monolithic disks, keep hold of the stream - we won't try to use the file name
@@ -94,7 +95,6 @@ namespace DiscUtils.Vmdk
                 }
             }
 
-            _fileLocator = new LocalFileLocator(Path.GetDirectoryName(path));
         }
 
         /// <summary>

--- a/Utilities/DiscUtils.Diagnostics/TracingStream.cs
+++ b/Utilities/DiscUtils.Diagnostics/TracingStream.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using DiscUtils.Internal;
 using DiscUtils.Streams;
 
 namespace DiscUtils.Diagnostics
@@ -154,7 +155,8 @@ namespace DiscUtils.Diagnostics
 
             if (!string.IsNullOrEmpty(path))
             {
-                _fileOut = new StreamWriter(new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite));
+                var locator = new LocalFileLocator(string.Empty);
+                _fileOut = new StreamWriter(locator.Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite));
             }
         }
 


### PR DESCRIPTION
This adds the option to modify the parameters for any FileStream, which is opened inside DiscUtils.

The first commit adds the LocalFileLocator (I've skipped the standalone binaries from Utilities), to reduce the number of places, where files are opened. The second commit introduces an event, which can be used to modify the parameters (filename, mode, share & access), wrap the filestream or return a completly different stream.

This allows us to modify the FileShare parameter for vhdx files (as described in #24) or wrap all FileStreams to workaround a huge performance penalty  (factor > 1000) in the `FileStream.Length` Property for files residing on a Cluster Shared Volume (CSV).

This may also be useful for unit testing, because the files to be opened don't even have to exist.