### PR TITLE
Low Level IO Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Buildlog-*\.txt
 *.suo
 *.user
 *.lock.json
+LaunchSettings.json
 
 .vs/
 Nuget/

--- a/Library/DiscUtils.Core/ApplePartitionMap/PartitionMap.cs
+++ b/Library/DiscUtils.Core/ApplePartitionMap/PartitionMap.cs
@@ -45,7 +45,7 @@ namespace DiscUtils.ApplePartitionMap
             _stream = stream;
 
             stream.Position = 0;
-            byte[] initialBytes = StreamUtilities.ReadFully(stream, 1024);
+            byte[] initialBytes = StreamUtilities.ReadExact(stream, 1024);
 
             BlockZero b0 = new BlockZero();
             b0.ReadFrom(initialBytes, 0);
@@ -53,7 +53,7 @@ namespace DiscUtils.ApplePartitionMap
             PartitionMapEntry initialPart = new PartitionMapEntry(_stream);
             initialPart.ReadFrom(initialBytes, 512);
 
-            byte[] partTableData = StreamUtilities.ReadFully(stream, (int)(initialPart.MapEntries - 1) * 512);
+            byte[] partTableData = StreamUtilities.ReadExact(stream, (int)(initialPart.MapEntries - 1) * 512);
 
             _partitions = new PartitionMapEntry[initialPart.MapEntries - 1];
             for (uint i = 0; i < initialPart.MapEntries - 1; ++i)

--- a/Library/DiscUtils.Core/ApplePartitionMap/PartitionMapFactory.cs
+++ b/Library/DiscUtils.Core/ApplePartitionMap/PartitionMapFactory.cs
@@ -38,7 +38,7 @@ namespace DiscUtils.ApplePartitionMap
 
             s.Position = 0;
 
-            byte[] initialBytes = StreamUtilities.ReadFully(s, 1024);
+            byte[] initialBytes = StreamUtilities.ReadExact(s, 1024);
 
             BlockZero b0 = new BlockZero();
             b0.ReadFrom(initialBytes, 0);

--- a/Library/DiscUtils.Core/Archives/TarFile.cs
+++ b/Library/DiscUtils.Core/Archives/TarFile.cs
@@ -45,7 +45,7 @@ namespace DiscUtils.Archives
             _files = new Dictionary<string, FileRecord>();
 
             TarHeader hdr = new TarHeader();
-            byte[] hdrBuf = StreamUtilities.ReadFully(_fileStream, TarHeader.Length);
+            byte[] hdrBuf = StreamUtilities.ReadExact(_fileStream, TarHeader.Length);
             hdr.ReadFrom(hdrBuf, 0);
             while (hdr.FileLength != 0 || !string.IsNullOrEmpty(hdr.FileName))
             {
@@ -53,7 +53,7 @@ namespace DiscUtils.Archives
                 _files.Add(record.Name, record);
                 _fileStream.Position += (hdr.FileLength + 511) / 512 * 512;
 
-                hdrBuf = StreamUtilities.ReadFully(_fileStream, TarHeader.Length);
+                hdrBuf = StreamUtilities.ReadExact(_fileStream, TarHeader.Length);
                 hdr.ReadFrom(hdrBuf, 0);
             }
         }

--- a/Library/DiscUtils.Core/Compression/ZlibStream.cs
+++ b/Library/DiscUtils.Core/Compression/ZlibStream.cs
@@ -52,7 +52,7 @@ namespace DiscUtils.Compression
             if (mode == CompressionMode.Decompress)
             {
                 // We just sanity check against expected header values...
-                byte[] headerBuffer = StreamUtilities.ReadFully(stream, 2);
+                byte[] headerBuffer = StreamUtilities.ReadExact(stream, 2);
                 ushort header = EndianUtilities.ToUInt16BigEndian(headerBuffer, 0);
 
                 if (header % 31 != 0)
@@ -140,7 +140,7 @@ namespace DiscUtils.Compression
                 if (_stream.CanSeek)
                 {
                     _stream.Seek(-4, SeekOrigin.End);
-                    byte[] footerBuffer = StreamUtilities.ReadFully(_stream, 4);
+                    byte[] footerBuffer = StreamUtilities.ReadExact(_stream, 4);
                     if (EndianUtilities.ToInt32BigEndian(footerBuffer, 0) != _adler32.Value)
                     {
                         throw new InvalidDataException("Corrupt decompressed data detected");

--- a/Library/DiscUtils.Core/LogicalDiskManager/Database.cs
+++ b/Library/DiscUtils.Core/LogicalDiskManager/Database.cs
@@ -43,7 +43,7 @@ namespace DiscUtils.LogicalDiskManager
 
             stream.Position = dbStart + _vmdb.HeaderSize;
 
-            buffer = StreamUtilities.ReadFully(stream, (int)(_vmdb.BlockSize * _vmdb.NumVBlks));
+            buffer = StreamUtilities.ReadExact(stream, (int)(_vmdb.BlockSize * _vmdb.NumVBlks));
 
             _records = new Dictionary<ulong, DatabaseRecord>();
             for (int i = 0; i < _vmdb.NumVBlks; ++i)

--- a/Library/DiscUtils.Core/Partitions/BiosExtendedPartitionTable.cs
+++ b/Library/DiscUtils.Core/Partitions/BiosExtendedPartitionTable.cs
@@ -45,7 +45,7 @@ namespace DiscUtils.Partitions
             while (partPos != 0)
             {
                 _disk.Position = (long)partPos * Sizes.Sector;
-                byte[] sector = StreamUtilities.ReadFully(_disk, Sizes.Sector);
+                byte[] sector = StreamUtilities.ReadExact(_disk, Sizes.Sector);
                 if (sector[510] != 0x55 || sector[511] != 0xAA)
                 {
                     throw new IOException("Invalid extended partition sector");
@@ -89,7 +89,7 @@ namespace DiscUtils.Partitions
                 extents.Add(new StreamExtent((long)partPos * Sizes.Sector, Sizes.Sector));
 
                 _disk.Position = (long)partPos * Sizes.Sector;
-                byte[] sector = StreamUtilities.ReadFully(_disk, Sizes.Sector);
+                byte[] sector = StreamUtilities.ReadExact(_disk, Sizes.Sector);
                 if (sector[510] != 0x55 || sector[511] != 0xAA)
                 {
                     throw new IOException("Invalid extended partition sector");

--- a/Library/DiscUtils.Core/Partitions/BiosPartitionTable.cs
+++ b/Library/DiscUtils.Core/Partitions/BiosPartitionTable.cs
@@ -115,7 +115,7 @@ namespace DiscUtils.Partitions
             if (disk.Length >= Sizes.Sector)
             {
                 disk.Position = 0;
-                byte[] bootSector = StreamUtilities.ReadFully(disk, Sizes.Sector);
+                byte[] bootSector = StreamUtilities.ReadExact(disk, Sizes.Sector);
                 if (bootSector[510] == 0x55 && bootSector[511] == 0xAA)
                 {
                     byte maxHead = 0;
@@ -150,7 +150,7 @@ namespace DiscUtils.Partitions
             }
 
             disk.Position = 0;
-            byte[] bootSector = StreamUtilities.ReadFully(disk, Sizes.Sector);
+            byte[] bootSector = StreamUtilities.ReadExact(disk, Sizes.Sector);
 
             // Check for the 'bootable sector' marker
             if (bootSector[510] != 0x55 || bootSector[511] != 0xAA)
@@ -222,7 +222,7 @@ namespace DiscUtils.Partitions
             if (data.Length >= Sizes.Sector)
             {
                 data.Position = 0;
-                bootSector = StreamUtilities.ReadFully(data, Sizes.Sector);
+                bootSector = StreamUtilities.ReadExact(data, Sizes.Sector);
             }
             else
             {
@@ -514,7 +514,7 @@ namespace DiscUtils.Partitions
         public void UpdateBiosGeometry(Geometry geometry)
         {
             _diskData.Position = 0;
-            byte[] bootSector = StreamUtilities.ReadFully(_diskData, Sizes.Sector);
+            byte[] bootSector = StreamUtilities.ReadExact(_diskData, Sizes.Sector);
 
             BiosPartitionRecord[] records = ReadPrimaryRecords(bootSector);
             for (int i = 0; i < records.Length; ++i)
@@ -627,7 +627,7 @@ namespace DiscUtils.Partitions
         private BiosPartitionRecord[] GetPrimaryRecords()
         {
             _diskData.Position = 0;
-            byte[] bootSector = StreamUtilities.ReadFully(_diskData, Sizes.Sector);
+            byte[] bootSector = StreamUtilities.ReadExact(_diskData, Sizes.Sector);
 
             return ReadPrimaryRecords(bootSector);
         }
@@ -640,7 +640,7 @@ namespace DiscUtils.Partitions
         private void WriteRecord(int i, BiosPartitionRecord newRecord)
         {
             _diskData.Position = 0;
-            byte[] bootSector = StreamUtilities.ReadFully(_diskData, Sizes.Sector);
+            byte[] bootSector = StreamUtilities.ReadExact(_diskData, Sizes.Sector);
             newRecord.WriteTo(bootSector, 0x01BE + i * 16);
             _diskData.Position = 0;
             _diskData.Write(bootSector, 0, bootSector.Length);
@@ -724,7 +724,7 @@ namespace DiscUtils.Partitions
             _diskGeometry = diskGeometry;
 
             _diskData.Position = 0;
-            byte[] bootSector = StreamUtilities.ReadFully(_diskData, Sizes.Sector);
+            byte[] bootSector = StreamUtilities.ReadExact(_diskData, Sizes.Sector);
             if (bootSector[510] != 0x55 || bootSector[511] != 0xAA)
             {
                 throw new IOException("Invalid boot sector - no magic number 0xAA55");

--- a/Library/DiscUtils.Core/Partitions/BiosPartitionedDiskBuilder.cs
+++ b/Library/DiscUtils.Core/Partitions/BiosPartitionedDiskBuilder.cs
@@ -107,7 +107,7 @@ namespace DiscUtils.Partitions
             foreach (StreamExtent extent in new BiosPartitionTable(sourceDisk).GetMetadataDiskExtents())
             {
                 sourceDisk.Content.Position = extent.Start;
-                byte[] buffer = StreamUtilities.ReadFully(sourceDisk.Content, (int)extent.Length);
+                byte[] buffer = StreamUtilities.ReadExact(sourceDisk.Content, (int)extent.Length);
                 _bootSectors.Position = extent.Start;
                 _bootSectors.Write(buffer, 0, buffer.Length);
             }
@@ -154,7 +154,7 @@ namespace DiscUtils.Partitions
             foreach (StreamExtent extent in PartitionTable.GetMetadataDiskExtents())
             {
                 _bootSectors.Position = extent.Start;
-                byte[] buffer = StreamUtilities.ReadFully(_bootSectors, (int)extent.Length);
+                byte[] buffer = StreamUtilities.ReadExact(_bootSectors, (int)extent.Length);
 
                 extents.Add(new BuilderBufferExtent(extent.Start, buffer));
             }

--- a/Library/DiscUtils.Core/Partitions/GuidPartitionTable.cs
+++ b/Library/DiscUtils.Core/Partitions/GuidPartitionTable.cs
@@ -362,7 +362,7 @@ namespace DiscUtils.Partitions
             _diskGeometry = diskGeometry;
 
             disk.Position = diskGeometry.BytesPerSector;
-            byte[] sector = StreamUtilities.ReadFully(disk, diskGeometry.BytesPerSector);
+            byte[] sector = StreamUtilities.ReadExact(disk, diskGeometry.BytesPerSector);
 
             _primaryHeader = new GptHeader(diskGeometry.BytesPerSector);
             if (!_primaryHeader.ReadFrom(sector, 0) || !ReadEntries(_primaryHeader))
@@ -558,7 +558,7 @@ namespace DiscUtils.Partitions
         private bool ReadEntries(GptHeader header)
         {
             _diskData.Position = header.PartitionEntriesLba * _diskGeometry.BytesPerSector;
-            _entryBuffer = StreamUtilities.ReadFully(_diskData, (int)(header.PartitionEntrySize * header.PartitionEntryCount));
+            _entryBuffer = StreamUtilities.ReadExact(_diskData, (int)(header.PartitionEntrySize * header.PartitionEntryCount));
             if (header.EntriesCrc != CalcEntriesCrc())
             {
                 return false;

--- a/Library/DiscUtils.Core/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Core/Properties/AssemblyInfo.cs
@@ -36,7 +36,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("DiscUtils")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-//[assembly: CLSCompliant(true)]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Library/DiscUtils.Core/VirtualDisk.cs
+++ b/Library/DiscUtils.Core/VirtualDisk.cs
@@ -523,7 +523,7 @@ namespace DiscUtils
 
             long oldPos = Content.Position;
             Content.Position = 0;
-            StreamUtilities.ReadFully(Content, sector, 0, Sizes.Sector);
+            StreamUtilities.ReadExact(Content, sector, 0, Sizes.Sector);
             Content.Position = oldPos;
 
             return sector;

--- a/Library/DiscUtils.Dmg/DiskImageFile.cs
+++ b/Library/DiscUtils.Dmg/DiskImageFile.cs
@@ -46,14 +46,14 @@ namespace DiscUtils.Dmg
             _ownsStream = ownsStream;
 
             stream.Position = stream.Length - _udifHeader.Size;
-            byte[] data = StreamUtilities.ReadFully(stream, _udifHeader.Size);
+            byte[] data = StreamUtilities.ReadExact(stream, _udifHeader.Size);
 
             _udifHeader.ReadFrom(data, 0);
 
             if (_udifHeader.SignatureValid)
             {
                 stream.Position = (long)_udifHeader.XmlOffset;
-                byte[] xmlData = StreamUtilities.ReadFully(stream, (int)_udifHeader.XmlLength);
+                byte[] xmlData = StreamUtilities.ReadExact(stream, (int)_udifHeader.XmlLength);
                 Dictionary<string, object> plist = Plist.Parse(new MemoryStream(xmlData));
 
                 _resources = ResourceFork.FromPlist(plist);

--- a/Library/DiscUtils.Dmg/UdifBuffer.cs
+++ b/Library/DiscUtils.Dmg/UdifBuffer.cs
@@ -91,7 +91,7 @@ namespace DiscUtils.Dmg
 
                     case RunType.Raw:
                         _stream.Position = _activeRun.CompOffset + bufferOffset;
-                        StreamUtilities.ReadFully(_stream, buffer, offset + totalCopied, toCopy);
+                        StreamUtilities.ReadExact(_stream, buffer, offset + totalCopied, toCopy);
                         break;
 
                     case RunType.AdcCompressed:
@@ -279,14 +279,14 @@ namespace DiscUtils.Dmg
                     _stream.Position = run.CompOffset + 2; // 2 byte zlib header
                     using (DeflateStream ds = new DeflateStream(_stream, CompressionMode.Decompress, true))
                     {
-                        StreamUtilities.ReadFully(ds, _decompBuffer, 0, toCopy);
+                        StreamUtilities.ReadExact(ds, _decompBuffer, 0, toCopy);
                     }
 
                     break;
 
                 case RunType.AdcCompressed:
                     _stream.Position = run.CompOffset;
-                    byte[] compressed = StreamUtilities.ReadFully(_stream, (int)run.CompLength);
+                    byte[] compressed = StreamUtilities.ReadExact(_stream, (int)run.CompLength);
                     if (ADCDecompress(compressed, 0, compressed.Length, _decompBuffer, 0) != toCopy)
                     {
                         throw new InvalidDataException("Run too short when decompressed");
@@ -300,7 +300,7 @@ namespace DiscUtils.Dmg
                             new BZip2DecoderStream(new SubStream(_stream, run.CompOffset, run.CompLength),
                                 Ownership.None))
                     {
-                        StreamUtilities.ReadFully(ds, _decompBuffer, 0, toCopy);
+                        StreamUtilities.ReadExact(ds, _decompBuffer, 0, toCopy);
                     }
 
                     break;

--- a/Library/DiscUtils.Ext/Directory.cs
+++ b/Library/DiscUtils.Ext/Directory.cs
@@ -47,7 +47,7 @@ namespace DiscUtils.Ext
                 long pos = 0;
                 while (pos < Inode.FileSize)
                 {
-                    StreamUtilities.ReadFully(content, blockSize * (long)relBlock, blockData, 0, (int)blockSize);
+                    StreamUtilities.ReadMaximum(content, blockSize * (long)relBlock, blockData, 0, (int)blockSize);
 
                     int blockPos = 0;
                     while (blockPos < blockSize)

--- a/Library/DiscUtils.Ext/ExtFileSystem.cs
+++ b/Library/DiscUtils.Ext/ExtFileSystem.cs
@@ -65,7 +65,7 @@ namespace DiscUtils.Ext
             }
 
             stream.Position = 1024;
-            byte[] superblockData = StreamUtilities.ReadFully(stream, 1024);
+            byte[] superblockData = StreamUtilities.ReadExact(stream, 1024);
 
             SuperBlock superblock = new SuperBlock();
             superblock.ReadFrom(superblockData, 0);

--- a/Library/DiscUtils.Ext/ExtentsFileBuffer.cs
+++ b/Library/DiscUtils.Ext/ExtentsFileBuffer.cs
@@ -193,7 +193,7 @@ namespace DiscUtils.Ext
         {
             uint blockSize = _context.SuperBlock.BlockSize;
             _context.RawStream.Position = idxEntry.LeafPhysicalBlock * blockSize;
-            byte[] buffer = StreamUtilities.ReadFully(_context.RawStream, (int)blockSize);
+            byte[] buffer = StreamUtilities.ReadExact(_context.RawStream, (int)blockSize);
             ExtentBlock subBlock = EndianUtilities.ToStruct<ExtentBlock>(buffer, 0);
             return subBlock;
         }

--- a/Library/DiscUtils.Ext/FileBuffer.cs
+++ b/Library/DiscUtils.Ext/FileBuffer.cs
@@ -83,7 +83,7 @@ namespace DiscUtils.Ext
                         if (_inode.IndirectBlock != 0)
                         {
                             _context.RawStream.Position = _inode.IndirectBlock * (long)blockSize + logicalBlock * 4;
-                            byte[] indirectData = StreamUtilities.ReadFully(_context.RawStream, 4);
+                            byte[] indirectData = StreamUtilities.ReadExact(_context.RawStream, 4);
                             physicalBlock = EndianUtilities.ToUInt32LittleEndian(indirectData, 0);
                         }
                     }
@@ -96,14 +96,14 @@ namespace DiscUtils.Ext
                             {
                                 _context.RawStream.Position = _inode.DoubleIndirectBlock * (long)blockSize +
                                                               logicalBlock / (blockSize / 4) * 4;
-                                byte[] indirectData = StreamUtilities.ReadFully(_context.RawStream, 4);
+                                byte[] indirectData = StreamUtilities.ReadExact(_context.RawStream, 4);
                                 uint indirectBlock = EndianUtilities.ToUInt32LittleEndian(indirectData, 0);
 
                                 if (indirectBlock != 0)
                                 {
                                     _context.RawStream.Position = indirectBlock * (long)blockSize +
                                                                   logicalBlock % (blockSize / 4) * 4;
-                                    StreamUtilities.ReadFully(_context.RawStream, indirectData, 0, 4);
+                                    StreamUtilities.ReadExact(_context.RawStream, indirectData, 0, 4);
                                     physicalBlock = EndianUtilities.ToUInt32LittleEndian(indirectData, 0);
                                 }
                             }

--- a/Library/DiscUtils.Ext/Symlink.cs
+++ b/Library/DiscUtils.Ext/Symlink.cs
@@ -35,7 +35,7 @@ namespace DiscUtils.Ext
             get
             {
                 IBuffer content = FileContent;
-                byte[] data = StreamUtilities.ReadFully(content, 0, (int)content.Capacity);
+                byte[] data = StreamUtilities.ReadExact(content, 0, (int)content.Capacity);
                 return EndianUtilities.BytesToZString(data, 0, data.Length).Replace('/', '\\');
             }
         }

--- a/Library/DiscUtils.Ext/VfsExtFileSystem.cs
+++ b/Library/DiscUtils.Ext/VfsExtFileSystem.cs
@@ -39,7 +39,7 @@ namespace DiscUtils.Ext
             : base(new ExtFileSystemOptions(parameters))
         {
             stream.Position = 1024;
-            byte[] superblockData = StreamUtilities.ReadFully(stream, 1024);
+            byte[] superblockData = StreamUtilities.ReadExact(stream, 1024);
 
             SuperBlock superblock = new SuperBlock();
             superblock.ReadFrom(superblockData, 0);
@@ -72,7 +72,7 @@ namespace DiscUtils.Ext
 
             stream.Position = blockDescStart;
             var bgDescSize = superblock.Has64Bit ? BlockGroup64.DescriptorSize64 : BlockGroup.DescriptorSize;
-            byte[] blockDescData = StreamUtilities.ReadFully(stream, (int)numGroups * bgDescSize);
+            byte[] blockDescData = StreamUtilities.ReadExact(stream, (int)numGroups * bgDescSize);
 
             _blockGroups = new BlockGroup[numGroups];
             for (int i = 0; i < numGroups; ++i)
@@ -87,7 +87,7 @@ namespace DiscUtils.Ext
             {
                 var journalInode = GetInode(superblock.JournalInode);
                 var journalDataStream = journalInode.GetContentBuffer(Context);
-                var journalData = StreamUtilities.ReadFully(journalDataStream, 0, 1024 + 12);
+                var journalData = StreamUtilities.ReadExact(journalDataStream, 0, 1024 + 12);
                 journalSuperBlock.ReadFrom(journalData, 0);
                 Context.JournalSuperblock = journalSuperBlock;
             }
@@ -167,7 +167,7 @@ namespace DiscUtils.Ext
 
             Context.RawStream.Position = (inodeBlockGroup.InodeTableBlock + block) * (long)superBlock.BlockSize +
                                          blockOffset * superBlock.InodeSize;
-            byte[] inodeData = StreamUtilities.ReadFully(Context.RawStream, superBlock.InodeSize);
+            byte[] inodeData = StreamUtilities.ReadExact(Context.RawStream, superBlock.InodeSize);
 
             return EndianUtilities.ToStruct<Inode>(inodeData, 0);
         }

--- a/Library/DiscUtils.Fat/ClusterReader.cs
+++ b/Library/DiscUtils.Fat/ClusterReader.cs
@@ -65,10 +65,7 @@ namespace DiscUtils.Fat
             uint firstSector = (uint)((cluster - 2) * _sectorsPerCluster + _firstDataSector);
 
             _stream.Position = firstSector * _bytesPerSector;
-            if (StreamUtilities.ReadFully(_stream, buffer, offset, _clusterSize) != _clusterSize)
-            {
-                throw new IOException("Failed to read cluster " + cluster);
-            }
+            StreamUtilities.ReadExact(_stream, buffer, offset, _clusterSize);
         }
 
         internal void WriteCluster(uint cluster, byte[] buffer, int offset)

--- a/Library/DiscUtils.Fat/DirectoryEntry.cs
+++ b/Library/DiscUtils.Fat/DirectoryEntry.cs
@@ -45,7 +45,7 @@ namespace DiscUtils.Fat
         {
             _options = options;
             _fatVariant = fatVariant;
-            byte[] buffer = StreamUtilities.ReadFully(stream, 32);
+            byte[] buffer = StreamUtilities.ReadExact(stream, 32);
             Load(buffer, 0);
         }
 

--- a/Library/DiscUtils.Fat/FatFileSystem.cs
+++ b/Library/DiscUtils.Fat/FatFileSystem.cs
@@ -391,7 +391,7 @@ namespace DiscUtils.Fat
             }
 
             stream.Position = 0;
-            byte[] bytes = StreamUtilities.ReadFully(stream, 512);
+            byte[] bytes = StreamUtilities.ReadExact(stream, 512);
             ushort bpbBytesPerSec = EndianUtilities.ToUInt16LittleEndian(bytes, 11);
             if (bpbBytesPerSec != 512)
             {

--- a/Library/DiscUtils.Fat/FileAllocationTable.cs
+++ b/Library/DiscUtils.Fat/FileAllocationTable.cs
@@ -40,7 +40,7 @@ namespace DiscUtils.Fat
             _numFats = numFats;
 
             _stream.Position = (firstFatSector + fatSize * activeFat) * Sizes.Sector;
-            _buffer = new FatBuffer(type, StreamUtilities.ReadFully(_stream, (int)(fatSize * Sizes.Sector)));
+            _buffer = new FatBuffer(type, StreamUtilities.ReadExact(_stream, (int)(fatSize * Sizes.Sector)));
         }
 
         internal bool IsFree(uint val)

--- a/Library/DiscUtils.HfsPlus/BTree_T.cs
+++ b/Library/DiscUtils.HfsPlus/BTree_T.cs
@@ -35,12 +35,12 @@ namespace DiscUtils.HfsPlus
         {
             _data = data;
 
-            byte[] headerInfo = StreamUtilities.ReadFully(_data, 0, 114);
+            byte[] headerInfo = StreamUtilities.ReadExact(_data, 0, 114);
 
             _header = new BTreeHeaderRecord();
             _header.ReadFrom(headerInfo, 14);
 
-            byte[] node0data = StreamUtilities.ReadFully(_data, 0, _header.NodeSize);
+            byte[] node0data = StreamUtilities.ReadExact(_data, 0, _header.NodeSize);
 
             BTreeHeaderNode node0 = BTreeNode.ReadNode(this, node0data, 0) as BTreeHeaderNode;
             node0.ReadFrom(node0data, 0);
@@ -68,7 +68,7 @@ namespace DiscUtils.HfsPlus
 
         internal BTreeKeyedNode<TKey> GetKeyedNode(uint nodeId)
         {
-            byte[] nodeData = StreamUtilities.ReadFully(_data, (int)nodeId * _header.NodeSize, _header.NodeSize);
+            byte[] nodeData = StreamUtilities.ReadExact(_data, (int)nodeId * _header.NodeSize, _header.NodeSize);
 
             BTreeKeyedNode<TKey> node = BTreeNode.ReadNode<TKey>(this, nodeData, 0) as BTreeKeyedNode<TKey>;
             node.ReadFrom(nodeData, 0);

--- a/Library/DiscUtils.HfsPlus/HfsPlusFileSystem.cs
+++ b/Library/DiscUtils.HfsPlus/HfsPlusFileSystem.cs
@@ -57,7 +57,7 @@ namespace DiscUtils.HfsPlus
 
             stream.Position = 1024;
 
-            byte[] headerBuf = StreamUtilities.ReadFully(stream, 512);
+            byte[] headerBuf = StreamUtilities.ReadExact(stream, 512);
             VolumeHeader hdr = new VolumeHeader();
             hdr.ReadFrom(headerBuf, 0);
 

--- a/Library/DiscUtils.HfsPlus/HfsPlusFileSystemImpl.cs
+++ b/Library/DiscUtils.HfsPlus/HfsPlusFileSystemImpl.cs
@@ -34,7 +34,7 @@ namespace DiscUtils.HfsPlus
         {
             s.Position = 1024;
 
-            byte[] headerBuf = StreamUtilities.ReadFully(s, 512);
+            byte[] headerBuf = StreamUtilities.ReadExact(s, 512);
             VolumeHeader hdr = new VolumeHeader();
             hdr.ReadFrom(headerBuf, 0);
 

--- a/Library/DiscUtils.Iscsi/ProtocolDataUnit.cs
+++ b/Library/DiscUtils.Iscsi/ProtocolDataUnit.cs
@@ -46,7 +46,7 @@ namespace DiscUtils.Iscsi
         {
             int numRead = 0;
 
-            byte[] headerData = StreamUtilities.ReadFully(stream, 48);
+            byte[] headerData = StreamUtilities.ReadExact(stream, 48);
             numRead += 48;
 
             byte[] contentData = null;
@@ -62,7 +62,7 @@ namespace DiscUtils.Iscsi
 
             if (bhs.DataSegmentLength > 0)
             {
-                contentData = StreamUtilities.ReadFully(stream, bhs.DataSegmentLength);
+                contentData = StreamUtilities.ReadExact(stream, bhs.DataSegmentLength);
                 numRead += bhs.DataSegmentLength;
 
                 if (dataDigestEnabled)
@@ -75,7 +75,7 @@ namespace DiscUtils.Iscsi
             int rem = 4 - numRead % 4;
             if (rem != 4)
             {
-                StreamUtilities.ReadFully(stream, rem);
+                StreamUtilities.ReadExact(stream, rem);
             }
 
             return new ProtocolDataUnit(headerData, contentData);
@@ -83,7 +83,7 @@ namespace DiscUtils.Iscsi
 
         private static uint ReadDigest(Stream stream)
         {
-            byte[] data = StreamUtilities.ReadFully(stream, 4);
+            byte[] data = StreamUtilities.ReadExact(stream, 4);
             return EndianUtilities.ToUInt32BigEndian(data, 0);
         }
     }

--- a/Library/DiscUtils.Iso9660/CDBuilder.cs
+++ b/Library/DiscUtils.Iso9660/CDBuilder.cs
@@ -429,7 +429,7 @@ namespace DiscUtils.Iso9660
                 return bootImage;
             }
 
-            byte[] bootData = StreamUtilities.ReadFully(bootImage, (int)bootImage.Length);
+            byte[] bootData = StreamUtilities.ReadExact(bootImage, (int)bootImage.Length);
 
             Array.Clear(bootData, 8, 56);
 

--- a/Library/DiscUtils.Iso9660/CDReader.cs
+++ b/Library/DiscUtils.Iso9660/CDReader.cs
@@ -184,7 +184,7 @@ namespace DiscUtils.Iso9660
             }
 
             data.Position = 0x8000;
-            int numRead = StreamUtilities.ReadFully(data, buffer, 0, IsoUtilities.SectorSize);
+            int numRead = StreamUtilities.ReadMaximum(data, buffer, 0, IsoUtilities.SectorSize);
             if (numRead != IsoUtilities.SectorSize)
             {
                 return false;

--- a/Library/DiscUtils.Iso9660/ReaderDirEntry.cs
+++ b/Library/DiscUtils.Iso9660/ReaderDirEntry.cs
@@ -71,7 +71,7 @@ namespace DiscUtils.Iso9660
                 if (clEntry != null)
                 {
                     _context.DataStream.Position = clEntry.ChildDirLocation * _context.VolumeDescriptor.LogicalBlockSize;
-                    byte[] firstSector = StreamUtilities.ReadFully(_context.DataStream,
+                    byte[] firstSector = StreamUtilities.ReadExact(_context.DataStream,
                         _context.VolumeDescriptor.LogicalBlockSize);
 
                     DirectoryRecord.ReadFrom(firstSector, 0, _context.VolumeDescriptor.CharacterEncoding, out _record);

--- a/Library/DiscUtils.Iso9660/ReaderDirectory.cs
+++ b/Library/DiscUtils.Iso9660/ReaderDirectory.cs
@@ -20,13 +20,13 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using DiscUtils.CoreCompat;
+using DiscUtils.Streams;
+using DiscUtils.Vfs;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using DiscUtils.CoreCompat;
-using DiscUtils.Streams;
-using DiscUtils.Vfs;
 
 namespace DiscUtils.Iso9660
 {
@@ -46,14 +46,10 @@ namespace DiscUtils.Iso9660
             uint totalRead = 0;
             while (totalRead < totalLength)
             {
-                int toRead = (int)Math.Min(buffer.Length, totalLength - totalRead);
-                uint bytesRead = (uint)StreamUtilities.ReadFully(extent, buffer, 0, toRead);
-                if (bytesRead != toRead)
-                {
-                    throw new IOException("Failed to read whole directory");
-                }
+                int bytesRead = (int)Math.Min(buffer.Length, totalLength - totalRead);
 
-                totalRead += bytesRead;
+                StreamUtilities.ReadExact(extent, buffer, 0, bytesRead);
+                totalRead += (uint)bytesRead;
 
                 uint pos = 0;
                 while (pos < bytesRead && buffer[pos] != 0)

--- a/Library/DiscUtils.Iso9660/Susp/SuspRecords.cs
+++ b/Library/DiscUtils.Iso9660/Susp/SuspRecords.cs
@@ -38,7 +38,7 @@ namespace DiscUtils.Iso9660
             {
                 context.DataStream.Position = contEntry.Block * (long)context.VolumeDescriptor.LogicalBlockSize +
                                               contEntry.BlockOffset;
-                byte[] contData = StreamUtilities.ReadFully(context.DataStream, (int)contEntry.Length);
+                byte[] contData = StreamUtilities.ReadExact(context.DataStream, (int)contEntry.Length);
 
                 contEntry = Parse(context, contData, 0);
             }

--- a/Library/DiscUtils.Iso9660/VfsCDReader.cs
+++ b/Library/DiscUtils.Iso9660/VfsCDReader.cs
@@ -485,7 +485,7 @@ namespace DiscUtils.Iso9660
         {
             context.DataStream.Position = context.VolumeDescriptor.RootDirectory.LocationOfExtent *
                                           context.VolumeDescriptor.LogicalBlockSize;
-            byte[] firstSector = StreamUtilities.ReadFully(context.DataStream, context.VolumeDescriptor.LogicalBlockSize);
+            byte[] firstSector = StreamUtilities.ReadExact(context.DataStream, context.VolumeDescriptor.LogicalBlockSize);
 
             DirectoryRecord rootSelfRecord;
             DirectoryRecord.ReadFrom(firstSector, 0, context.VolumeDescriptor.CharacterEncoding, out rootSelfRecord);
@@ -514,7 +514,7 @@ namespace DiscUtils.Iso9660
             if (_bootCatalog == null && _bootVolDesc != null)
             {
                 _data.Position = _bootVolDesc.CatalogSector * IsoUtilities.SectorSize;
-                _bootCatalog = StreamUtilities.ReadFully(_data, IsoUtilities.SectorSize);
+                _bootCatalog = StreamUtilities.ReadExact(_data, IsoUtilities.SectorSize);
             }
 
             return _bootCatalog;

--- a/Library/DiscUtils.Lvm/PhysicalVolume.cs
+++ b/Library/DiscUtils.Lvm/PhysicalVolume.cs
@@ -41,14 +41,14 @@ namespace DiscUtils.Lvm
             PhysicalVolumeLabel = physicalVolumeLabel;
             PvHeader = new PvHeader();
             content.Position = (long) (physicalVolumeLabel.Sector * SECTOR_SIZE);
-            var buffer = StreamUtilities.ReadFully(content, SECTOR_SIZE);
+            var buffer = StreamUtilities.ReadExact(content, SECTOR_SIZE);
             PvHeader.ReadFrom(buffer, (int) physicalVolumeLabel.Offset);
             if (PvHeader.MetadataDiskAreas.Length > 0)
             {
                 var area = PvHeader.MetadataDiskAreas[0];
                 var metadata = new VolumeGroupMetadata();
                 content.Position = (long) area.Offset;
-                buffer = StreamUtilities.ReadFully(content, (int) area.Length);
+                buffer = StreamUtilities.ReadExact(content, (int) area.Length);
                 metadata.ReadFrom(buffer, 0x0);
                 VgMetadata = metadata;
             }
@@ -79,8 +79,11 @@ namespace DiscUtils.Lvm
             byte[] buffer = new byte[SECTOR_SIZE];
             for (uint i = 0; i < 4; i++)
             {
-                if (StreamUtilities.ReadFully(content, buffer, 0, SECTOR_SIZE) != SECTOR_SIZE)
+                if (StreamUtilities.ReadMaximum(content, buffer, 0, SECTOR_SIZE) != SECTOR_SIZE)
+                {
                     return false;
+                }
+
                 var label = EndianUtilities.BytesToString(buffer, 0x0, 0x8);
                 if (label == PhysicalVolumeLabel.LABEL_ID)
                 {

--- a/Library/DiscUtils.Nfs/RpcTcpTransport.cs
+++ b/Library/DiscUtils.Nfs/RpcTcpTransport.cs
@@ -184,11 +184,11 @@ namespace DiscUtils.Nfs
 
             while (!lastFragFound)
             {
-                byte[] header = StreamUtilities.ReadFully(_tcpStream, 4);
+                byte[] header = StreamUtilities.ReadExact(_tcpStream, 4);
                 uint headerVal = EndianUtilities.ToUInt32BigEndian(header, 0);
 
                 lastFragFound = (headerVal & 0x80000000) != 0;
-                byte[] frag = StreamUtilities.ReadFully(_tcpStream, (int)(headerVal & 0x7FFFFFFF));
+                byte[] frag = StreamUtilities.ReadExact(_tcpStream, (int)(headerVal & 0x7FFFFFFF));
 
                 if (ms != null)
                 {

--- a/Library/DiscUtils.Nfs/XdrDataReader.cs
+++ b/Library/DiscUtils.Nfs/XdrDataReader.cs
@@ -38,11 +38,11 @@ namespace DiscUtils.Nfs
 
         public override byte[] ReadBytes(int count)
         {
-            byte[] buffer = StreamUtilities.ReadFully(_stream, count);
+            byte[] buffer = StreamUtilities.ReadExact(_stream, count);
 
             if ((count & 0x3) != 0)
             {
-                StreamUtilities.ReadFully(_stream, 4 - (count & 0x3));
+                StreamUtilities.ReadExact(_stream, 4 - (count & 0x3));
             }
 
             return buffer;

--- a/Library/DiscUtils.Ntfs/AttributeDefinitions.cs
+++ b/Library/DiscUtils.Ntfs/AttributeDefinitions.cs
@@ -63,7 +63,7 @@ namespace DiscUtils.Ntfs
             byte[] buffer = new byte[AttributeDefinitionRecord.Size];
             using (Stream s = file.OpenStream(AttributeType.Data, null, FileAccess.Read))
             {
-                while (StreamUtilities.ReadFully(s, buffer, 0, buffer.Length) == buffer.Length)
+                while (StreamUtilities.ReadMaximum(s, buffer, 0, buffer.Length) == buffer.Length)
                 {
                     AttributeDefinitionRecord record = new AttributeDefinitionRecord();
                     record.Read(buffer, 0);

--- a/Library/DiscUtils.Ntfs/File.cs
+++ b/Library/DiscUtils.Ntfs/File.cs
@@ -654,7 +654,7 @@ namespace DiscUtils.Ntfs
             AttributeRecord newAttrRecord = _records[0].GetAttribute(id);
 
             IBuffer attrBuffer = attr.GetDataBuffer();
-            byte[] tempData = StreamUtilities.ReadFully(attrBuffer, 0, (int)Math.Min(maxData, attrBuffer.Capacity));
+            byte[] tempData = StreamUtilities.ReadExact(attrBuffer, 0, (int)Math.Min(maxData, attrBuffer.Capacity));
 
             RemoveAttributeExtents(attr);
             attr.SetExtent(_records[0].Reference, newAttrRecord);
@@ -1075,7 +1075,7 @@ namespace DiscUtils.Ntfs
             AttributeRecord newAttrRecord = _records[0].GetAttribute(id);
 
             IBuffer attrBuffer = attr.GetDataBuffer();
-            byte[] tempData = StreamUtilities.ReadFully(attrBuffer, 0, (int)Math.Min(maxData, attrBuffer.Capacity));
+            byte[] tempData = StreamUtilities.ReadExact(attrBuffer, 0, (int)Math.Min(maxData, attrBuffer.Capacity));
 
             RemoveAttributeExtents(attr);
             attr.SetExtent(_records[0].Reference, newAttrRecord);

--- a/Library/DiscUtils.Ntfs/Index.cs
+++ b/Library/DiscUtils.Ntfs/Index.cs
@@ -55,7 +55,7 @@ namespace DiscUtils.Ntfs
 
             using (Stream s = _file.OpenStream(AttributeType.IndexRoot, _name, FileAccess.Read))
             {
-                byte[] buffer = StreamUtilities.ReadFully(s, (int)s.Length);
+                byte[] buffer = StreamUtilities.ReadExact(s, (int)s.Length);
                 _rootNode = new IndexNode(WriteRootNodeToDisk, 0, this, true, buffer, IndexRoot.HeaderOffset);
 
                 // Give the attribute some room to breathe, so long as it doesn't squeeze others out

--- a/Library/DiscUtils.Ntfs/IndexBlock.cs
+++ b/Library/DiscUtils.Ntfs/IndexBlock.cs
@@ -50,7 +50,7 @@ namespace DiscUtils.Ntfs
             Stream stream = index.AllocationStream;
             _streamPosition = index.IndexBlockVcnToPosition(parentEntry.ChildrenVirtualCluster);
             stream.Position = _streamPosition;
-            byte[] buffer = StreamUtilities.ReadFully(stream, (int)index.IndexBufferSize);
+            byte[] buffer = StreamUtilities.ReadExact(stream, (int)index.IndexBufferSize);
             FromBytes(buffer, 0);
         }
 

--- a/Library/DiscUtils.Ntfs/MasterFileTable.cs
+++ b/Library/DiscUtils.Ntfs/MasterFileTable.cs
@@ -135,7 +135,7 @@ namespace DiscUtils.Ntfs
                     uint index = 0;
                     while (mftStream.Position < mftStream.Length)
                     {
-                        byte[] recordData = StreamUtilities.ReadFully(mftStream, RecordSize);
+                        byte[] recordData = StreamUtilities.ReadExact(mftStream, RecordSize);
 
                         if (EndianUtilities.BytesToString(recordData, 0, 4) != "FILE")
                         {
@@ -192,7 +192,7 @@ namespace DiscUtils.Ntfs
         public FileRecord GetBootstrapRecord()
         {
             _recordStream.Position = 0;
-            byte[] mftSelfRecordData = StreamUtilities.ReadFully(_recordStream, RecordSize);
+            byte[] mftSelfRecordData = StreamUtilities.ReadExact(_recordStream, RecordSize);
             FileRecord mftSelfRecord = new FileRecord(_bytesPerSector);
             mftSelfRecord.FromBytes(mftSelfRecordData, 0);
             _recordCache[MftIndex] = mftSelfRecord;
@@ -367,7 +367,7 @@ namespace DiscUtils.Ntfs
                 if ((index + 1) * RecordSize <= _recordStream.Length)
                 {
                     _recordStream.Position = index * RecordSize;
-                    byte[] recordBuffer = StreamUtilities.ReadFully(_recordStream, RecordSize);
+                    byte[] recordBuffer = StreamUtilities.ReadExact(_recordStream, RecordSize);
 
                     result = new FileRecord(_bytesPerSector);
                     result.FromBytes(recordBuffer, 0, ignoreMagic);

--- a/Library/DiscUtils.Ntfs/NtfsFileSystem.cs
+++ b/Library/DiscUtils.Ntfs/NtfsFileSystem.cs
@@ -70,7 +70,7 @@ namespace DiscUtils.Ntfs
             _fileCache = new ObjectCache<long, File>();
 
             stream.Position = 0;
-            byte[] bytes = StreamUtilities.ReadFully(stream, 512);
+            byte[] bytes = StreamUtilities.ReadExact(stream, 512);
 
             _context.BiosParameterBlock = BiosParameterBlock.FromBytes(bytes, 0);
             if (!IsValidBPB(_context.BiosParameterBlock, stream.Length))
@@ -1003,7 +1003,7 @@ namespace DiscUtils.Ntfs
         {
             using (Stream s = OpenFile(@"\$Boot", FileMode.Open))
             {
-                return StreamUtilities.ReadFully(s, (int)s.Length);
+                return StreamUtilities.ReadExact(s, (int)s.Length);
             }
         }
 
@@ -1152,7 +1152,7 @@ namespace DiscUtils.Ntfs
                     // If there's an existing reparse point, unhook it.
                     using (Stream contentStream = stream.Open(FileAccess.Read))
                     {
-                        byte[] oldRpBuffer = StreamUtilities.ReadFully(contentStream, (int)contentStream.Length);
+                        byte[] oldRpBuffer = StreamUtilities.ReadExact(contentStream, (int)contentStream.Length);
                         ReparsePointRecord rp = new ReparsePointRecord();
                         rp.ReadFrom(oldRpBuffer, 0);
                         _context.ReparsePoints.Remove(rp.Tag, dirEntry.Reference);
@@ -1217,7 +1217,7 @@ namespace DiscUtils.Ntfs
 
                     using (Stream contentStream = stream.Open(FileAccess.Read))
                     {
-                        byte[] buffer = StreamUtilities.ReadFully(contentStream, (int)contentStream.Length);
+                        byte[] buffer = StreamUtilities.ReadExact(contentStream, (int)contentStream.Length);
                         rp.ReadFrom(buffer, 0);
                         return new ReparsePoint((int)rp.Tag, rp.Content);
                     }
@@ -1632,7 +1632,7 @@ namespace DiscUtils.Ntfs
             }
 
             stream.Position = 0;
-            byte[] bytes = StreamUtilities.ReadFully(stream, 512);
+            byte[] bytes = StreamUtilities.ReadExact(stream, 512);
             BiosParameterBlock bpb = BiosParameterBlock.FromBytes(bytes, 0);
 
             return IsValidBPB(bpb, stream.Length);
@@ -1901,7 +1901,7 @@ namespace DiscUtils.Ntfs
             _context.BiosParameterBlock.NumHeads = (ushort)geometry.HeadsPerCylinder;
 
             _context.RawStream.Position = 0;
-            byte[] bpbSector = StreamUtilities.ReadFully(_context.RawStream, 512);
+            byte[] bpbSector = StreamUtilities.ReadExact(_context.RawStream, 512);
 
             _context.BiosParameterBlock.ToBytes(bpbSector, 0);
 
@@ -2172,7 +2172,7 @@ namespace DiscUtils.Ntfs
 
                 using (Stream contentStream = stream.Open(FileAccess.Read))
                 {
-                    byte[] buffer = StreamUtilities.ReadFully(contentStream, (int)contentStream.Length);
+                    byte[] buffer = StreamUtilities.ReadExact(contentStream, (int)contentStream.Length);
                     rp.ReadFrom(buffer, 0);
                 }
 

--- a/Library/DiscUtils.Ntfs/NtfsFileSystemChecker.cs
+++ b/Library/DiscUtils.Ntfs/NtfsFileSystemChecker.cs
@@ -105,7 +105,7 @@ namespace DiscUtils.Ntfs
             _context.Options = new NtfsOptions();
 
             _context.RawStream.Position = 0;
-            byte[] bytes = StreamUtilities.ReadFully(_context.RawStream, 512);
+            byte[] bytes = StreamUtilities.ReadExact(_context.RawStream, 512);
 
             _context.BiosParameterBlock = BiosParameterBlock.FromBytes(bytes, 0);
 
@@ -123,7 +123,7 @@ namespace DiscUtils.Ntfs
         private void DoCheck()
         {
             _context.RawStream.Position = 0;
-            byte[] bytes = StreamUtilities.ReadFully(_context.RawStream, 512);
+            byte[] bytes = StreamUtilities.ReadExact(_context.RawStream, 512);
 
             _context.BiosParameterBlock = BiosParameterBlock.FromBytes(bytes, 0);
 
@@ -315,7 +315,7 @@ namespace DiscUtils.Ntfs
             byte[] rootBuffer;
             using (Stream s = file.OpenStream(AttributeType.IndexRoot, name, FileAccess.Read))
             {
-                rootBuffer = StreamUtilities.ReadFully(s, (int)s.Length);
+                rootBuffer = StreamUtilities.ReadExact(s, (int)s.Length);
             }
 
             Bitmap indexBitmap = null;
@@ -423,7 +423,7 @@ namespace DiscUtils.Ntfs
                 long index = 0;
                 while (mftStream.Position < mftStream.Length)
                 {
-                    byte[] recordData = StreamUtilities.ReadFully(mftStream, recordLength);
+                    byte[] recordData = StreamUtilities.ReadExact(mftStream, recordLength);
 
                     string magic = EndianUtilities.BytesToString(recordData, 0, 4);
                     if (magic != "FILE")

--- a/Library/DiscUtils.Ntfs/NtfsStream.cs
+++ b/Library/DiscUtils.Ntfs/NtfsStream.cs
@@ -59,7 +59,7 @@ namespace DiscUtils.Ntfs
             byte[] buffer;
             using (Stream s = Open(FileAccess.Read))
             {
-                buffer = StreamUtilities.ReadFully(s, (int)s.Length);
+                buffer = StreamUtilities.ReadExact(s, (int)s.Length);
             }
 
             T value = new T();

--- a/Library/DiscUtils.Ntfs/RawClusterStream.cs
+++ b/Library/DiscUtils.Ntfs/RawClusterStream.cs
@@ -312,13 +312,7 @@ namespace DiscUtils.Ntfs
                 {
                     long lcn = _cookedRuns[runIdx].StartLcn + (focusVcn - run.StartVcn);
                     _fsStream.Position = lcn * _bytesPerCluster;
-                    int numRead = StreamUtilities.ReadFully(_fsStream, buffer, offset + totalRead * _bytesPerCluster,
-                        toRead * _bytesPerCluster);
-                    if (numRead != toRead * _bytesPerCluster)
-                    {
-                        throw new IOException(string.Format(CultureInfo.InvariantCulture,
-                            "Short read, reading {0} clusters starting at LCN {1}", toRead, lcn));
-                    }
+                    StreamUtilities.ReadExact(_fsStream, buffer, offset + totalRead * _bytesPerCluster, toRead * _bytesPerCluster);
                 }
 
                 totalRead += toRead;

--- a/Library/DiscUtils.Ntfs/SecurityDescriptors.cs
+++ b/Library/DiscUtils.Ntfs/SecurityDescriptors.cs
@@ -80,7 +80,7 @@ namespace DiscUtils.Ntfs
 
             using (Stream s = _file.OpenStream(AttributeType.Data, "$SDS", FileAccess.Read))
             {
-                byte[] buffer = StreamUtilities.ReadFully(s, (int)s.Length);
+                byte[] buffer = StreamUtilities.ReadExact(s, (int)s.Length);
 
                 foreach (KeyValuePair<IdIndexKey, IdIndexData> entry in _idIndex.Entries)
                 {
@@ -217,7 +217,7 @@ namespace DiscUtils.Ntfs
             using (Stream s = _file.OpenStream(AttributeType.Data, "$SDS", FileAccess.Read))
             {
                 s.Position = data.SdsOffset;
-                byte[] buffer = StreamUtilities.ReadFully(s, data.SdsLength);
+                byte[] buffer = StreamUtilities.ReadExact(s, data.SdsLength);
 
                 SecurityDescriptorRecord record = new SecurityDescriptorRecord();
                 record.Read(buffer, 0);

--- a/Library/DiscUtils.Ntfs/StructuredNtfsAttribute.cs
+++ b/Library/DiscUtils.Ntfs/StructuredNtfsAttribute.cs
@@ -94,7 +94,7 @@ namespace DiscUtils.Ntfs
             {
                 using (Stream s = Open(FileAccess.Read))
                 {
-                    byte[] buffer = StreamUtilities.ReadFully(s, (int)Length);
+                    byte[] buffer = StreamUtilities.ReadExact(s, (int)Length);
                     _structure.ReadFrom(buffer, 0);
                     _hasContent = s.Length != 0;
                 }

--- a/Library/DiscUtils.Ntfs/UpperCase.cs
+++ b/Library/DiscUtils.Ntfs/UpperCase.cs
@@ -37,7 +37,7 @@ namespace DiscUtils.Ntfs
             {
                 _table = new char[s.Length / 2];
 
-                byte[] buffer = StreamUtilities.ReadFully(s, (int)s.Length);
+                byte[] buffer = StreamUtilities.ReadExact(s, (int)s.Length);
 
                 for (int i = 0; i < _table.Length; ++i)
                 {

--- a/Library/DiscUtils.OpticalDisk/Mode2Buffer.cs
+++ b/Library/DiscUtils.OpticalDisk/Mode2Buffer.cs
@@ -76,12 +76,7 @@ namespace DiscUtils.OpticalDisk
                 long sector = thisPos / DiscImageFile.Mode1SectorSize;
                 int sectorOffset = (int)(thisPos - sector * DiscImageFile.Mode1SectorSize);
 
-                int numRead = StreamUtilities.ReadFully(_wrapped, sector * DiscImageFile.Mode2SectorSize, _iobuffer, 0,
-                    DiscImageFile.Mode2SectorSize);
-                if (numRead < DiscImageFile.Mode2SectorSize)
-                {
-                    throw new IOException("Failed to read entire sector");
-                }
+                StreamUtilities.ReadExact(_wrapped, sector * DiscImageFile.Mode2SectorSize, _iobuffer, 0, DiscImageFile.Mode2SectorSize);
 
                 int bytesToCopy = Math.Min(DiscImageFile.Mode1SectorSize - sectorOffset, totalToRead - totalRead);
                 Array.Copy(_iobuffer, 24 + sectorOffset, buffer, offset + totalRead, bytesToCopy);

--- a/Library/DiscUtils.Registry/Bin.cs
+++ b/Library/DiscUtils.Registry/Bin.cs
@@ -49,12 +49,12 @@ namespace DiscUtils.Registry
             _streamPos = stream.Position;
 
             stream.Position = _streamPos;
-            byte[] buffer = StreamUtilities.ReadFully(stream, 0x20);
+            byte[] buffer = StreamUtilities.ReadExact(stream, 0x20);
             _header = new BinHeader();
             _header.ReadFrom(buffer, 0);
 
             _fileStream.Position = _streamPos;
-            _buffer = StreamUtilities.ReadFully(_fileStream, _header.BinSize);
+            _buffer = StreamUtilities.ReadExact(_fileStream, _header.BinSize);
 
             // Gather list of all free cells.
             _freeCells = new List<Range<int, int>>();

--- a/Library/DiscUtils.Registry/RegistryHive.cs
+++ b/Library/DiscUtils.Registry/RegistryHive.cs
@@ -62,7 +62,7 @@ namespace DiscUtils.Registry
             _fileStream.Position = 0;
             _ownsStream = ownership;
 
-            byte[] buffer = StreamUtilities.ReadFully(_fileStream, HiveHeader.HeaderSize);
+            byte[] buffer = StreamUtilities.ReadExact(_fileStream, HiveHeader.HeaderSize);
 
             _header = new HiveHeader();
             _header.ReadFrom(buffer, 0);
@@ -72,7 +72,7 @@ namespace DiscUtils.Registry
             while (pos < _header.Length)
             {
                 _fileStream.Position = BinStart + pos;
-                byte[] headerBuffer = StreamUtilities.ReadFully(_fileStream, BinHeader.HeaderSize);
+                byte[] headerBuffer = StreamUtilities.ReadExact(_fileStream, BinHeader.HeaderSize);
                 BinHeader header = new BinHeader();
                 header.ReadFrom(headerBuffer, 0);
                 _bins.Add(header);
@@ -345,7 +345,7 @@ namespace DiscUtils.Registry
             _header.Sequence1++;
             _header.Sequence2++;
             _fileStream.Position = 0;
-            byte[] hiveHeader = StreamUtilities.ReadFully(_fileStream, _header.Size);
+            byte[] hiveHeader = StreamUtilities.ReadExact(_fileStream, _header.Size);
             _header.WriteTo(hiveHeader, 0);
             _fileStream.Position = 0;
             _fileStream.Write(hiveHeader, 0, hiveHeader.Length);

--- a/Library/DiscUtils.Sdi/SdiFile.cs
+++ b/Library/DiscUtils.Sdi/SdiFile.cs
@@ -55,13 +55,13 @@ namespace DiscUtils.Sdi
             _stream = stream;
             _ownership = ownership;
 
-            byte[] page = StreamUtilities.ReadFully(_stream, 512);
+            byte[] page = StreamUtilities.ReadExact(_stream, 512);
 
             _header = new FileHeader();
             _header.ReadFrom(page, 0);
 
             _stream.Position = _header.PageAlignment * 512;
-            byte[] toc = StreamUtilities.ReadFully(_stream, (int)(_header.PageAlignment * 512));
+            byte[] toc = StreamUtilities.ReadExact(_stream, (int)(_header.PageAlignment * 512));
 
             _sections = new List<SectionRecord>();
             int pos = 0;

--- a/Library/DiscUtils.SquashFs/BuilderFile.cs
+++ b/Library/DiscUtils.SquashFs/BuilderFile.cs
@@ -89,7 +89,7 @@ namespace DiscUtils.SquashFs
                 }
 
                 long startPos = outStream.Position;
-                int bufferedBytes = StreamUtilities.ReadFully(_source, context.IoBuffer, 0, context.DataBlockSize);
+                int bufferedBytes = StreamUtilities.ReadMaximum(_source, context.IoBuffer, 0, context.DataBlockSize);
 
                 if (bufferedBytes < context.DataBlockSize)
                 {
@@ -110,7 +110,7 @@ namespace DiscUtils.SquashFs
                     while (bufferedBytes > 0)
                     {
                         _lengths.Add(context.WriteDataBlock(context.IoBuffer, 0, bufferedBytes));
-                        bufferedBytes = StreamUtilities.ReadFully(_source, context.IoBuffer, 0, context.DataBlockSize);
+                        bufferedBytes = StreamUtilities.ReadMaximum(_source, context.IoBuffer, 0, context.DataBlockSize);
                         _inode.FileSize += (uint)bufferedBytes;
                     }
                 }

--- a/Library/DiscUtils.SquashFs/SquashFileSystemReader.cs
+++ b/Library/DiscUtils.SquashFs/SquashFileSystemReader.cs
@@ -68,7 +68,7 @@ namespace DiscUtils.SquashFs
                 return false;
             }
 
-            byte[] buffer = StreamUtilities.ReadFully(stream, superBlock.Size);
+            byte[] buffer = StreamUtilities.ReadExact(stream, superBlock.Size);
             superBlock.ReadFrom(buffer, 0);
 
             return superBlock.Magic == SuperBlock.SquashFsMagic;

--- a/Library/DiscUtils.Streams/Block/BlockCacheStream.cs
+++ b/Library/DiscUtils.Streams/Block/BlockCacheStream.cs
@@ -269,21 +269,17 @@ namespace DiscUtils.Streams
 
                     // Allow for the end of the stream not being block-aligned
                     long readPosition = (firstBlock + blocksRead) * blockSize;
-                    int bytesToRead = (int)Math.Min(blocksToRead * (long)blockSize, Length - readPosition);
+                    int bytesRead = (int)Math.Min(blocksToRead * (long)blockSize, Length - readPosition);
 
                     // Do the read
                     _stats.TotalReadsOut++;
                     _wrappedStream.Position = readPosition;
-                    int bytesRead = StreamUtilities.ReadFully(_wrappedStream, _readBuffer, 0, bytesToRead);
-                    if (bytesRead != bytesToRead)
-                    {
-                        throw new IOException("Short read before end of stream");
-                    }
+                    StreamUtilities.ReadExact(_wrappedStream, _readBuffer, 0, bytesRead);
 
                     // Cache the read blocks
                     for (int i = 0; i < blocksToRead; ++i)
                     {
-                        int copyBytes = Math.Min(blockSize, bytesToRead - i * blockSize);
+                        int copyBytes = Math.Min(blockSize, bytesRead - i * blockSize);
                         block = _cache.GetBlock(firstBlock + blocksRead + i);
                         Array.Copy(_readBuffer, i * blockSize, block.Data, 0, copyBytes);
                         block.Available = copyBytes;

--- a/Library/DiscUtils.Streams/ReaderWriter/BigEndianDataWriter.cs
+++ b/Library/DiscUtils.Streams/ReaderWriter/BigEndianDataWriter.cs
@@ -20,6 +20,7 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
 using System.IO;
 
 namespace DiscUtils.Streams
@@ -31,42 +32,37 @@ namespace DiscUtils.Streams
 
         public override void Write(ushort value)
         {
-            byte[] buffer = new byte[2];
-            EndianUtilities.WriteBytesBigEndian(value, buffer, 0);
-            _stream.Write(buffer, 0, buffer.Length);
+            EnsureBuffer();
+            EndianUtilities.WriteBytesBigEndian(value, _buffer, 0);
+            FlushBuffer(sizeof(UInt16));
         }
 
         public override void Write(int value)
         {
-            byte[] buffer = new byte[4];
-            EndianUtilities.WriteBytesBigEndian(value, buffer, 0);
-            _stream.Write(buffer, 0, buffer.Length);
+            EnsureBuffer();
+            EndianUtilities.WriteBytesBigEndian(value, _buffer, 0);
+            FlushBuffer(sizeof(Int32));
         }
 
         public override void Write(uint value)
         {
-            byte[] buffer = new byte[4];
-            EndianUtilities.WriteBytesBigEndian(value, buffer, 0);
-            _stream.Write(buffer, 0, buffer.Length);
+            EnsureBuffer();
+            EndianUtilities.WriteBytesBigEndian(value, _buffer, 0);
+            FlushBuffer(sizeof(UInt32));
         }
 
         public override void Write(long value)
         {
-            byte[] buffer = new byte[8];
-            EndianUtilities.WriteBytesBigEndian(value, buffer, 0);
-            _stream.Write(buffer, 0, buffer.Length);
+            EnsureBuffer();
+            EndianUtilities.WriteBytesBigEndian(value, _buffer, 0);
+            FlushBuffer(sizeof(Int64));
         }
 
         public override void Write(ulong value)
         {
-            byte[] buffer = new byte[8];
-            EndianUtilities.WriteBytesBigEndian(value, buffer, 0);
-            _stream.Write(buffer, 0, buffer.Length);
-        }
-
-        public override void WriteBytes(byte[] value, int offset, int count)
-        {
-            _stream.Write(value, offset, count);
+            EnsureBuffer();
+            EndianUtilities.WriteBytesBigEndian(value, _buffer, 0);
+            FlushBuffer(sizeof(UInt64));
         }
     }
 }

--- a/Library/DiscUtils.Streams/ReaderWriter/DataReader.cs
+++ b/Library/DiscUtils.Streams/ReaderWriter/DataReader.cs
@@ -20,6 +20,7 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
 using System.IO;
 
 namespace DiscUtils.Streams
@@ -29,7 +30,11 @@ namespace DiscUtils.Streams
     /// </summary>
     public abstract class DataReader
     {
-        protected Stream _stream;
+        private const int _bufferSize = sizeof(UInt64);
+
+        protected readonly Stream _stream;
+
+        protected byte[] _buffer;
 
         public DataReader(Stream stream)
         {
@@ -61,6 +66,19 @@ namespace DiscUtils.Streams
 
         public abstract ulong ReadUInt64();
 
-        public abstract byte[] ReadBytes(int count);
+        public virtual byte[] ReadBytes(int count)
+        {
+            return StreamUtilities.ReadExact(_stream, count);
+        }
+
+        protected void ReadToBuffer(int count)
+        {
+            if (_buffer == null)
+            {
+                _buffer = new byte[_bufferSize];
+            }
+
+            StreamUtilities.ReadExact(_stream, _buffer, 0, count);
+        }
     }
 }

--- a/Library/DiscUtils.Streams/ReaderWriter/DataWriter.cs
+++ b/Library/DiscUtils.Streams/ReaderWriter/DataWriter.cs
@@ -20,13 +20,18 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
 using System.IO;
 
 namespace DiscUtils.Streams
 {
     public abstract class DataWriter
     {
-        protected Stream _stream;
+        private const int _bufferSize = sizeof(UInt64);
+
+        protected readonly Stream _stream;
+
+        protected byte[] _buffer;
 
         public DataWriter(Stream stream)
         {
@@ -43,11 +48,32 @@ namespace DiscUtils.Streams
 
         public abstract void Write(ulong value);
 
-        public abstract void WriteBytes(byte[] value, int offset, int count);
-
-        public void WriteBytes(byte[] value)
+        public virtual void WriteBytes(byte[] value, int offset, int count)
         {
-            WriteBytes(value, 0, value.Length);
+            _stream.Write(value, offset, count);
+        }
+
+        public virtual void WriteBytes(byte[] value)
+        {
+            _stream.Write(value, 0, value.Length);
+        }
+
+        public virtual void Flush()
+        {
+            _stream.Flush();
+        }
+
+        protected void EnsureBuffer()
+        {
+            if (_buffer == null)
+            {
+                _buffer = new byte[_bufferSize];
+            }
+        }
+
+        protected void FlushBuffer(int count)
+        {
+            _stream.Write(_buffer, 0, count);
         }
     }
 }

--- a/Library/DiscUtils.Streams/ReaderWriter/LittleEndianDataReader.cs
+++ b/Library/DiscUtils.Streams/ReaderWriter/LittleEndianDataReader.cs
@@ -20,6 +20,7 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
 using System.IO;
 
 namespace DiscUtils.Streams
@@ -34,32 +35,32 @@ namespace DiscUtils.Streams
 
         public override ushort ReadUInt16()
         {
-            return EndianUtilities.ToUInt16LittleEndian(StreamUtilities.ReadFully(_stream, 2), 0);
+            ReadToBuffer(sizeof(UInt16));
+            return EndianUtilities.ToUInt16LittleEndian(_buffer, 0);
         }
 
         public override int ReadInt32()
         {
-            return EndianUtilities.ToInt32LittleEndian(StreamUtilities.ReadFully(_stream, 4), 0);
+            ReadToBuffer(sizeof(Int32));
+            return EndianUtilities.ToInt32LittleEndian(_buffer, 0);
         }
 
         public override uint ReadUInt32()
         {
-            return EndianUtilities.ToUInt32LittleEndian(StreamUtilities.ReadFully(_stream, 4), 0);
+            ReadToBuffer(sizeof(UInt32));
+            return EndianUtilities.ToUInt32LittleEndian(_buffer, 0);
         }
 
         public override long ReadInt64()
         {
-            return EndianUtilities.ToInt64LittleEndian(StreamUtilities.ReadFully(_stream, 8), 0);
+            ReadToBuffer(sizeof(Int64));
+            return EndianUtilities.ToInt64LittleEndian(_buffer, 0);
         }
 
         public override ulong ReadUInt64()
         {
-            return EndianUtilities.ToUInt64LittleEndian(StreamUtilities.ReadFully(_stream, 8), 0);
-        }
-
-        public override byte[] ReadBytes(int count)
-        {
-            return StreamUtilities.ReadFully(_stream, count);
+            ReadToBuffer(sizeof(UInt64));
+            return EndianUtilities.ToUInt64LittleEndian(_buffer, 0);
         }
     }
 }

--- a/Library/DiscUtils.Streams/StreamPump.cs
+++ b/Library/DiscUtils.Streams/StreamPump.cs
@@ -203,8 +203,8 @@ namespace DiscUtils.Streams
                 long extentOffset = 0;
                 while (extentOffset < extent.Length)
                 {
-                    int toRead = (int)Math.Min(copyBuffer.Length, extent.Length - extentOffset);
-                    int numRead = StreamUtilities.ReadFully(inStream, copyBuffer, 0, toRead);
+                    int numRead = (int)Math.Min(copyBuffer.Length, extent.Length - extentOffset);
+                    StreamUtilities.ReadExact(inStream, copyBuffer, 0, numRead);
                     BytesRead += numRead;
 
                     int copyBufferOffset = 0;

--- a/Library/DiscUtils.Streams/Util/StreamUtilities.cs
+++ b/Library/DiscUtils.Streams/Util/StreamUtilities.cs
@@ -59,45 +59,115 @@ namespace DiscUtils.Streams
         #region Stream Manipulation
 
         /// <summary>
+        /// Read bytes until buffer filled or throw EndOfStreamException.
+        /// </summary>
+        /// <param name="stream">The stream to read.</param>
+        /// <param name="buffer">The buffer to populate.</param>
+        /// <param name="offset">Offset in the buffer to start.</param>
+        /// <param name="count">The number of bytes to read.</param>
+        public static void ReadExact(Stream stream, byte[] buffer, int offset, int count)
+        {
+            int originalCount = count;
+
+            while (count > 0)
+            {
+                int numRead = stream.Read(buffer, offset, count);
+
+                if (numRead == 0)
+                {
+                    throw new EndOfStreamException("Unable to complete read of " + originalCount + " bytes");
+                }
+
+                offset += numRead;
+                count -= numRead;
+            }
+        }
+
+        /// <summary>
+        /// Read bytes until buffer filled or throw EndOfStreamException.
+        /// </summary>
+        /// <param name="stream">The stream to read.</param>
+        /// <param name="count">The number of bytes to read.</param>
+        /// <returns>The data read from the stream.</returns>
+        public static byte[] ReadExact(Stream stream, int count)
+        {
+            byte[] buffer = new byte[count];
+
+            ReadExact(stream, buffer, 0, count);
+
+            return buffer;
+        }
+
+        /// <summary>
+        /// Read bytes until buffer filled or throw EndOfStreamException.
+        /// </summary>
+        /// <param name="buffer">The stream to read.</param>
+        /// <param name="pos">The position in buffer to read from.</param>
+        /// <param name="data">The buffer to populate.</param>
+        /// <param name="offset">Offset in the buffer to start.</param>
+        /// <param name="count">The number of bytes to read.</param>
+        public static void ReadExact(IBuffer buffer, long pos, byte[] data, int offset, int count)
+        {
+            int originalCount = count;
+
+            while (count > 0)
+            {
+                int numRead = buffer.Read(pos, data, offset, count);
+
+                if (numRead == 0)
+                {
+                    throw new EndOfStreamException("Unable to complete read of " + originalCount + " bytes");
+                }
+
+                pos += numRead;
+                offset += numRead;
+                count -= numRead;
+            }
+        }
+
+        /// <summary>
+        /// Read bytes until buffer filled or throw EndOfStreamException.
+        /// </summary>
+        /// <param name="buffer">The buffer to read.</param>
+        /// <param name="pos">The position in buffer to read from.</param>
+        /// <param name="count">The number of bytes to read.</param>
+        /// <returns>The data read from the stream.</returns>
+        public static byte[] ReadExact(IBuffer buffer, long pos, int count)
+        {
+            byte[] result = new byte[count];
+
+            ReadExact(buffer, pos, result, 0, count);
+
+            return result;
+        }
+
+        /// <summary>
         /// Read bytes until buffer filled or EOF.
         /// </summary>
         /// <param name="stream">The stream to read.</param>
         /// <param name="buffer">The buffer to populate.</param>
         /// <param name="offset">Offset in the buffer to start.</param>
-        /// <param name="length">The number of bytes to read.</param>
+        /// <param name="count">The number of bytes to read.</param>
         /// <returns>The number of bytes actually read.</returns>
-        public static int ReadFully(Stream stream, byte[] buffer, int offset, int length)
+        public static int ReadMaximum(Stream stream, byte[] buffer, int offset, int count)
         {
             int totalRead = 0;
-            int numRead = stream.Read(buffer, offset, length);
-            while (numRead > 0)
+
+            while (count > 0)
             {
-                totalRead += numRead;
-                if (totalRead == length)
+                int numRead = stream.Read(buffer, offset, count);
+
+                if (numRead == 0)
                 {
-                    break;
+                    return totalRead;
                 }
 
-                numRead = stream.Read(buffer, offset + totalRead, length - totalRead);
+                offset += numRead;
+                count -= numRead;
+                totalRead += numRead;
             }
 
             return totalRead;
-        }
-
-        /// <summary>
-        /// Read bytes until buffer filled or throw IOException.
-        /// </summary>
-        /// <param name="stream">The stream to read.</param>
-        /// <param name="count">The number of bytes to read.</param>
-        /// <returns>The data read from the stream.</returns>
-        public static byte[] ReadFully(Stream stream, int count)
-        {
-            byte[] buffer = new byte[count];
-            if (ReadFully(stream, buffer, 0, count) == count)
-            {
-                return buffer;
-            }
-            throw new IOException("Unable to complete read of " + count + " bytes");
         }
 
         /// <summary>
@@ -107,51 +177,38 @@ namespace DiscUtils.Streams
         /// <param name="pos">The position in buffer to read from.</param>
         /// <param name="data">The buffer to populate.</param>
         /// <param name="offset">Offset in the buffer to start.</param>
-        /// <param name="length">The number of bytes to read.</param>
+        /// <param name="count">The number of bytes to read.</param>
         /// <returns>The number of bytes actually read.</returns>
-        public static int ReadFully(IBuffer buffer, long pos, byte[] data, int offset, int length)
+        public static int ReadMaximum(IBuffer buffer, long pos, byte[] data, int offset, int count)
         {
             int totalRead = 0;
-            int numRead = buffer.Read(pos, data, offset, length);
-            while (numRead > 0)
+
+            while (count > 0)
             {
-                totalRead += numRead;
-                if (totalRead == length)
+                int numRead = buffer.Read(pos, data, offset, count);
+
+                if (numRead == 0)
                 {
-                    break;
+                    return totalRead;
                 }
 
-                numRead = buffer.Read(pos, data, offset + totalRead, length - totalRead);
+                pos += numRead;
+                offset += numRead;
+                count -= numRead;
+                totalRead += numRead;
             }
 
             return totalRead;
         }
 
         /// <summary>
-        /// Read bytes until buffer filled or throw IOException.
-        /// </summary>
-        /// <param name="buffer">The buffer to read.</param>
-        /// <param name="pos">The position in buffer to read from.</param>
-        /// <param name="count">The number of bytes to read.</param>
-        /// <returns>The data read from the stream.</returns>
-        public static byte[] ReadFully(IBuffer buffer, long pos, int count)
-        {
-            byte[] result = new byte[count];
-            if (ReadFully(buffer, pos, result, 0, count) == count)
-            {
-                return result;
-            }
-            throw new IOException("Unable to complete read of " + count + " bytes");
-        }
-
-        /// <summary>
-        /// Read bytes until buffer filled or throw IOException.
+        /// Read bytes until buffer filled or throw EndOfStreamException.
         /// </summary>
         /// <param name="buffer">The buffer to read.</param>
         /// <returns>The data read from the stream.</returns>
         public static byte[] ReadAll(IBuffer buffer)
         {
-            return ReadFully(buffer, 0, (int)buffer.Capacity);
+            return ReadExact(buffer, 0, (int)buffer.Capacity);
         }
 
         /// <summary>
@@ -161,7 +218,7 @@ namespace DiscUtils.Streams
         /// <returns>The sector data as a byte array.</returns>
         public static byte[] ReadSector(Stream stream)
         {
-            return ReadFully(stream, Sizes.Sector);
+            return ReadExact(stream, Sizes.Sector);
         }
 
         /// <summary>
@@ -174,7 +231,7 @@ namespace DiscUtils.Streams
             where T : IByteArraySerializable, new()
         {
             T result = new T();
-            byte[] buffer = ReadFully(stream, result.Size);
+            byte[] buffer = ReadExact(stream, result.Size);
             result.ReadFrom(buffer, 0);
             return result;
         }
@@ -190,7 +247,7 @@ namespace DiscUtils.Streams
             where T : IByteArraySerializable, new()
         {
             T result = new T();
-            byte[] buffer = ReadFully(stream, length);
+            byte[] buffer = ReadExact(stream, length);
             result.ReadFrom(buffer, 0);
             return result;
         }
@@ -217,13 +274,12 @@ namespace DiscUtils.Streams
         /// <remarks>Copying starts at the current stream positions.</remarks>
         public static void PumpStreams(Stream source, Stream dest)
         {
-            byte[] buffer = new byte[64 * 1024];
+            byte[] buffer = new byte[8192];
+            int numRead;
 
-            int numRead = source.Read(buffer, 0, buffer.Length);
-            while (numRead != 0)
+            while ((numRead = source.Read(buffer, 0, buffer.Length)) > 0)
             {
                 dest.Write(buffer, 0, numRead);
-                numRead = source.Read(buffer, 0, buffer.Length);
             }
         }
 

--- a/Library/DiscUtils.Swap/SwapFileSystem.cs
+++ b/Library/DiscUtils.Swap/SwapFileSystem.cs
@@ -82,7 +82,7 @@ namespace DiscUtils.Swap
                 return null;
             }
             stream.Position = 0;
-            byte[] headerData = StreamUtilities.ReadFully(stream, SwapHeader.PageSize);
+            byte[] headerData = StreamUtilities.ReadExact(stream, SwapHeader.PageSize);
             SwapHeader header = new SwapHeader();
             header.ReadFrom(headerData, 0);
             return header;

--- a/Library/DiscUtils.Udf/DescriptorTag.cs
+++ b/Library/DiscUtils.Udf/DescriptorTag.cs
@@ -83,7 +83,7 @@ namespace DiscUtils.Udf
 
         public static bool TryFromStream(Stream stream, out DescriptorTag result)
         {
-            byte[] next = StreamUtilities.ReadFully(stream, 512);
+            byte[] next = StreamUtilities.ReadExact(stream, 512);
             if (!IsValid(next, 0))
             {
                 result = null;

--- a/Library/DiscUtils.Udf/Directory.cs
+++ b/Library/DiscUtils.Udf/Directory.cs
@@ -41,7 +41,7 @@ namespace DiscUtils.Udf
 
             _entries = new List<FileIdentifier>();
 
-            byte[] contentBytes = StreamUtilities.ReadFully(FileContent, 0, (int)FileContent.Capacity);
+            byte[] contentBytes = StreamUtilities.ReadExact(FileContent, 0, (int)FileContent.Capacity);
 
             int pos = 0;
             while (pos < contentBytes.Length)

--- a/Library/DiscUtils.Udf/MetadataPartition.cs
+++ b/Library/DiscUtils.Udf/MetadataPartition.cs
@@ -40,7 +40,7 @@ namespace DiscUtils.Udf
             PhysicalPartition physical = context.PhysicalPartitions[partitionMap.PartitionNumber];
             long fileEntryPos = partitionMap.MetadataFileLocation * (long)volumeDescriptor.LogicalBlockSize;
 
-            byte[] entryData = StreamUtilities.ReadFully(physical.Content, fileEntryPos, _context.PhysicalSectorSize);
+            byte[] entryData = StreamUtilities.ReadExact(physical.Content, fileEntryPos, _context.PhysicalSectorSize);
             if (!DescriptorTag.IsValid(entryData, 0))
             {
                 throw new IOException("Invalid descriptor tag looking for Metadata file entry");

--- a/Library/DiscUtils.Udf/TaggedDescriptor.cs
+++ b/Library/DiscUtils.Udf/TaggedDescriptor.cs
@@ -35,7 +35,7 @@ namespace DiscUtils.Udf
         public static T FromStream(Stream stream, uint sector, uint sectorSize)
         {
             stream.Position = sector * (long)sectorSize;
-            byte[] buffer = StreamUtilities.ReadFully(stream, 512);
+            byte[] buffer = StreamUtilities.ReadExact(stream, 512);
 
             T result = new T();
             result.ReadFrom(buffer, 0);

--- a/Library/DiscUtils.Udf/UdfReader.cs
+++ b/Library/DiscUtils.Udf/UdfReader.cs
@@ -72,7 +72,7 @@ namespace DiscUtils.Udf
             while (validDescriptor)
             {
                 data.Position = vdpos;
-                int numRead = StreamUtilities.ReadFully(data, buffer, 0, IsoUtilities.SectorSize);
+                int numRead = StreamUtilities.ReadMaximum(data, buffer, 0, IsoUtilities.SectorSize);
                 if (numRead != IsoUtilities.SectorSize)
                 {
                     break;

--- a/Library/DiscUtils.Udf/UdfUtilities.cs
+++ b/Library/DiscUtils.Udf/UdfUtilities.cs
@@ -175,7 +175,7 @@ namespace DiscUtils.Udf
         {
             LogicalPartition partition = context.LogicalPartitions[extent.ExtentLocation.Partition];
             long pos = extent.ExtentLocation.LogicalBlock * partition.LogicalBlockSize;
-            return StreamUtilities.ReadFully(partition.Content, pos, (int)extent.ExtentLength);
+            return StreamUtilities.ReadExact(partition.Content, pos, (int)extent.ExtentLength);
         }
 
         private static short ForceRange(short min, short max, short val)

--- a/Library/DiscUtils.Vdi/DiskStream.cs
+++ b/Library/DiscUtils.Vdi/DiskStream.cs
@@ -189,7 +189,7 @@ namespace DiscUtils.Vdi
                     long filePos = _fileHeader.DataOffset + _fileHeader.BlockExtraSize + blockOffset +
                                    offsetInBlock;
                     _fileStream.Position = filePos;
-                    StreamUtilities.ReadFully(_fileStream, buffer, offset + numRead, toRead);
+                    StreamUtilities.ReadExact(_fileStream, buffer, offset + numRead, toRead);
                 }
 
                 _position += toRead;
@@ -357,7 +357,7 @@ namespace DiscUtils.Vdi
         {
             _fileStream.Position = _fileHeader.BlocksOffset;
 
-            byte[] buffer = StreamUtilities.ReadFully(_fileStream, _fileHeader.BlockCount * 4);
+            byte[] buffer = StreamUtilities.ReadExact(_fileStream, _fileHeader.BlockCount * 4);
 
             _blockTable = new uint[_fileHeader.BlockCount];
             for (int i = 0; i < _fileHeader.BlockCount; ++i)

--- a/Library/DiscUtils.Vdi/HeaderRecord.cs
+++ b/Library/DiscUtils.Vdi/HeaderRecord.cs
@@ -89,11 +89,11 @@ namespace DiscUtils.Vdi
             else
             {
                 long savedPos = s.Position;
-                headerSize = EndianUtilities.ToInt32LittleEndian(StreamUtilities.ReadFully(s, 4), 0);
+                headerSize = EndianUtilities.ToInt32LittleEndian(StreamUtilities.ReadExact(s, 4), 0);
                 s.Position = savedPos;
             }
 
-            byte[] buffer = StreamUtilities.ReadFully(s, headerSize);
+            byte[] buffer = StreamUtilities.ReadExact(s, headerSize);
             Read(version, buffer, 0);
         }
 

--- a/Library/DiscUtils.Vdi/PreHeaderRecord.cs
+++ b/Library/DiscUtils.Vdi/PreHeaderRecord.cs
@@ -53,7 +53,7 @@ namespace DiscUtils.Vdi
 
         public void Read(Stream s)
         {
-            byte[] buffer = StreamUtilities.ReadFully(s, 72);
+            byte[] buffer = StreamUtilities.ReadExact(s, 72);
             Read(buffer, 0);
         }
 

--- a/Library/DiscUtils.Vhd/DiskImageFile.cs
+++ b/Library/DiscUtils.Vhd/DiskImageFile.cs
@@ -615,7 +615,7 @@ namespace DiscUtils.Vhd
                     || pl.PlatformCode == ParentLocator.PlatformCodeWindowsRelativeUnicode)
                 {
                     _fileStream.Position = pl.PlatformDataOffset;
-                    byte[] buffer = StreamUtilities.ReadFully(_fileStream, pl.PlatformDataLength);
+                    byte[] buffer = StreamUtilities.ReadExact(_fileStream, pl.PlatformDataLength);
                     string locationVal = Encoding.Unicode.GetString(buffer);
 
                     if (pl.PlatformCode == ParentLocator.PlatformCodeWindowsAbsoluteUnicode)
@@ -646,7 +646,7 @@ namespace DiscUtils.Vhd
         private void ReadFooter(bool fallbackToFront)
         {
             _fileStream.Position = _fileStream.Length - Sizes.Sector;
-            byte[] sector = StreamUtilities.ReadFully(_fileStream, Sizes.Sector);
+            byte[] sector = StreamUtilities.ReadExact(_fileStream, Sizes.Sector);
 
             _footer = Footer.FromBytes(sector, 0);
 
@@ -658,7 +658,7 @@ namespace DiscUtils.Vhd
                 }
 
                 _fileStream.Position = 0;
-                StreamUtilities.ReadFully(_fileStream, sector, 0, Sizes.Sector);
+                StreamUtilities.ReadExact(_fileStream, sector, 0, Sizes.Sector);
 
                 _footer = Footer.FromBytes(sector, 0);
                 if (!_footer.IsValid())

--- a/Library/DiscUtils.Vhd/DiskImageFileInfo.cs
+++ b/Library/DiscUtils.Vhd/DiskImageFileInfo.cs
@@ -154,7 +154,7 @@ namespace DiscUtils.Vhd
                         || pl.PlatformCode == ParentLocator.PlatformCodeWindowsRelativeUnicode)
                     {
                         _vhdStream.Position = pl.PlatformDataOffset;
-                        byte[] buffer = StreamUtilities.ReadFully(_vhdStream, pl.PlatformDataLength);
+                        byte[] buffer = StreamUtilities.ReadExact(_vhdStream, pl.PlatformDataLength);
                         vals.Add(Encoding.Unicode.GetString(buffer));
                     }
                 }

--- a/Library/DiscUtils.Vhd/DynamicHeader.cs
+++ b/Library/DiscUtils.Vhd/DynamicHeader.cs
@@ -149,7 +149,7 @@ namespace DiscUtils.Vhd
 
         internal static DynamicHeader FromStream(Stream stream)
         {
-            return FromBytes(StreamUtilities.ReadFully(stream, 1024), 0);
+            return FromBytes(StreamUtilities.ReadExact(stream, 1024), 0);
         }
 
         private uint CalculateChecksum()

--- a/Library/DiscUtils.Vhd/FileChecker.cs
+++ b/Library/DiscUtils.Vhd/FileChecker.cs
@@ -124,7 +124,7 @@ namespace DiscUtils.Vhd
             }
 
             _fileStream.Position = _dynamicHeader.TableOffset;
-            byte[] batData = StreamUtilities.ReadFully(_fileStream, batSize);
+            byte[] batData = StreamUtilities.ReadExact(_fileStream, batSize);
             uint[] bat = new uint[batSize / 4];
             for (int i = 0; i < bat.Length; ++i)
             {
@@ -357,7 +357,7 @@ namespace DiscUtils.Vhd
         private void CheckFooter()
         {
             _fileStream.Position = _fileStream.Length - Sizes.Sector;
-            byte[] sector = StreamUtilities.ReadFully(_fileStream, Sizes.Sector);
+            byte[] sector = StreamUtilities.ReadExact(_fileStream, Sizes.Sector);
 
             _footer = Footer.FromBytes(sector, 0);
             if (!_footer.IsValid())
@@ -369,7 +369,7 @@ namespace DiscUtils.Vhd
         private void CheckHeader()
         {
             _fileStream.Position = 0;
-            byte[] headerSector = StreamUtilities.ReadFully(_fileStream, Sizes.Sector);
+            byte[] headerSector = StreamUtilities.ReadExact(_fileStream, Sizes.Sector);
 
             Footer header = Footer.FromBytes(headerSector, 0);
             if (!header.IsValid())
@@ -378,7 +378,7 @@ namespace DiscUtils.Vhd
             }
 
             _fileStream.Position = _fileStream.Length - Sizes.Sector;
-            byte[] footerSector = StreamUtilities.ReadFully(_fileStream, Sizes.Sector);
+            byte[] footerSector = StreamUtilities.ReadExact(_fileStream, Sizes.Sector);
 
             if (!Utilities.AreEqual(footerSector, headerSector))
             {

--- a/Library/DiscUtils.Vhd/Header.cs
+++ b/Library/DiscUtils.Vhd/Header.cs
@@ -32,7 +32,7 @@ namespace DiscUtils.Vhd
 
         public static Header FromStream(Stream stream)
         {
-            return FromBytes(StreamUtilities.ReadFully(stream, 16), 0);
+            return FromBytes(StreamUtilities.ReadExact(stream, 16), 0);
         }
 
         public static Header FromBytes(byte[] data, int offset)

--- a/Library/DiscUtils.Vhdx/Chunk.cs
+++ b/Library/DiscUtils.Vhdx/Chunk.cs
@@ -56,7 +56,7 @@ namespace DiscUtils.Vhdx
             _blocksPerChunk = blocksPerChunk;
 
             _bat.Position = _chunk * (_blocksPerChunk + 1) * 8;
-            _batData = StreamUtilities.ReadFully(bat, (_blocksPerChunk + 1) * 8);
+            _batData = StreamUtilities.ReadExact(bat, (_blocksPerChunk + 1) * 8);
         }
 
         private bool HasSectorBitmap
@@ -151,7 +151,7 @@ namespace DiscUtils.Vhdx
             if (_sectorBitmap == null)
             {
                 _file.Position = SectorBitmapPos;
-                _sectorBitmap = StreamUtilities.ReadFully(_file, (int)Sizes.OneMiB);
+                _sectorBitmap = StreamUtilities.ReadExact(_file, (int)Sizes.OneMiB);
             }
 
             return _sectorBitmap;

--- a/Library/DiscUtils.Vhdx/ContentStream.cs
+++ b/Library/DiscUtils.Vhdx/ContentStream.cs
@@ -188,7 +188,7 @@ namespace DiscUtils.Vhdx
                 if (blockStatus == PayloadBlockStatus.FullyPresent)
                 {
                     _fileStream.Position = chunk.GetBlockPosition(blockIndex) + blockOffset;
-                    int read = StreamUtilities.ReadFully(_fileStream, buffer, offset + totalRead,
+                    int read = StreamUtilities.ReadMaximum(_fileStream, buffer, offset + totalRead,
                         Math.Min(blockBytesRemaining, totalToRead - totalRead));
 
                     totalRead += read;
@@ -205,12 +205,12 @@ namespace DiscUtils.Vhdx
                     if (present)
                     {
                         _fileStream.Position = chunk.GetBlockPosition(blockIndex) + blockOffset;
-                        read = StreamUtilities.ReadFully(_fileStream, buffer, offset + totalRead, toRead);
+                        read = StreamUtilities.ReadMaximum(_fileStream, buffer, offset + totalRead, toRead);
                     }
                     else
                     {
                         _parentStream.Position = _position + totalRead;
-                        read = StreamUtilities.ReadFully(_parentStream, buffer, offset + totalRead, toRead);
+                        read = StreamUtilities.ReadMaximum(_parentStream, buffer, offset + totalRead, toRead);
                     }
 
                     totalRead += read;
@@ -218,7 +218,7 @@ namespace DiscUtils.Vhdx
                 else if (blockStatus == PayloadBlockStatus.NotPresent)
                 {
                     _parentStream.Position = _position + totalRead;
-                    int read = StreamUtilities.ReadFully(_parentStream, buffer, offset + totalRead,
+                    int read = StreamUtilities.ReadMaximum(_parentStream, buffer, offset + totalRead,
                         Math.Min(blockBytesRemaining, totalToRead - totalRead));
 
                     totalRead += read;

--- a/Library/DiscUtils.Vhdx/DiskImageFile.cs
+++ b/Library/DiscUtils.Vhdx/DiskImageFile.cs
@@ -634,7 +634,7 @@ namespace DiscUtils.Vhdx
         private IEnumerable<StreamExtent> BatControlledFileExtents()
         {
             _batStream.Position = 0;
-            byte[] batData = StreamUtilities.ReadFully(_batStream, (int)_batStream.Length);
+            byte[] batData = StreamUtilities.ReadExact(_batStream, (int)_batStream.Length);
 
             uint blockSize = _metadata.FileParameters.BlockSize;
             long chunkSize = (1L << 23) * _metadata.LogicalSectorSize;

--- a/Library/DiscUtils.Vhdx/LogEntry.cs
+++ b/Library/DiscUtils.Vhdx/LogEntry.cs
@@ -100,7 +100,7 @@ namespace DiscUtils.Vhdx
             long position = logStream.Position;
 
             byte[] sectorBuffer = new byte[LogSectorSize];
-            StreamUtilities.ReadFully(logStream, sectorBuffer, 0, sectorBuffer.Length);
+            StreamUtilities.ReadExact(logStream, sectorBuffer, 0, sectorBuffer.Length);
 
             uint sig = EndianUtilities.ToUInt32LittleEndian(sectorBuffer, 0);
             if (sig != LogEntryHeader.LogEntrySignature)
@@ -121,7 +121,7 @@ namespace DiscUtils.Vhdx
             byte[] logEntryBuffer = new byte[header.EntryLength];
             Array.Copy(sectorBuffer, logEntryBuffer, LogSectorSize);
 
-            StreamUtilities.ReadFully(logStream, logEntryBuffer, LogSectorSize, logEntryBuffer.Length - LogSectorSize);
+            StreamUtilities.ReadExact(logStream, logEntryBuffer, LogSectorSize, logEntryBuffer.Length - LogSectorSize);
 
             EndianUtilities.WriteBytesLittleEndian(0, logEntryBuffer, 4);
             if (header.Checksum !=

--- a/Library/DiscUtils.Vhdx/LogEntry.cs
+++ b/Library/DiscUtils.Vhdx/LogEntry.cs
@@ -100,7 +100,11 @@ namespace DiscUtils.Vhdx
             long position = logStream.Position;
 
             byte[] sectorBuffer = new byte[LogSectorSize];
-            StreamUtilities.ReadExact(logStream, sectorBuffer, 0, sectorBuffer.Length);
+            if (StreamUtilities.ReadMaximum(logStream, sectorBuffer, 0, sectorBuffer.Length) != sectorBuffer.Length)
+            {
+                entry = null;
+                return false;
+            }
 
             uint sig = EndianUtilities.ToUInt32LittleEndian(sectorBuffer, 0);
             if (sig != LogEntryHeader.LogEntrySignature)

--- a/Library/DiscUtils.Vhdx/Metadata.cs
+++ b/Library/DiscUtils.Vhdx/Metadata.cs
@@ -167,7 +167,7 @@ namespace DiscUtils.Vhdx
             if (Table.Entries.TryGetValue(key, out entry))
             {
                 _regionStream.Position = entry.Offset;
-                byte[] data = StreamUtilities.ReadFully(_regionStream, ReflectionHelper.SizeOf<T>());
+                byte[] data = StreamUtilities.ReadExact(_regionStream, ReflectionHelper.SizeOf<T>());
                 return reader(data, 0);
             }
 

--- a/Library/DiscUtils.Vmdk/CommonSparseExtentStream.cs
+++ b/Library/DiscUtils.Vmdk/CommonSparseExtentStream.cs
@@ -369,7 +369,7 @@ namespace DiscUtils.Vmdk
 
             _globalDirectory = new uint[numGTs];
             _fileStream.Position = _header.GdOffset * Sizes.Sector;
-            byte[] gdAsBytes = StreamUtilities.ReadFully(_fileStream, numGTs * 4);
+            byte[] gdAsBytes = StreamUtilities.ReadExact(_fileStream, numGTs * 4);
             for (int i = 0; i < _globalDirectory.Length; ++i)
             {
                 _globalDirectory[i] = EndianUtilities.ToUInt32LittleEndian(gdAsBytes, i * 4);
@@ -401,7 +401,7 @@ namespace DiscUtils.Vmdk
 
             // Not cached, so read
             _fileStream.Position = (long)_globalDirectory[index] * Sizes.Sector;
-            byte[] newGrainTable = StreamUtilities.ReadFully(_fileStream, (int)_header.NumGTEsPerGT * 4);
+            byte[] newGrainTable = StreamUtilities.ReadExact(_fileStream, (int)_header.NumGTEsPerGT * 4);
             _currentGrainTable = index;
             _grainTable = newGrainTable;
 

--- a/Library/DiscUtils.Vmdk/DiskImageFile.cs
+++ b/Library/DiscUtils.Vmdk/DiskImageFile.cs
@@ -984,7 +984,7 @@ namespace DiscUtils.Vmdk
         private void LoadDescriptor(Stream s)
         {
             s.Position = 0;
-            byte[] header = StreamUtilities.ReadFully(s, (int)Math.Min(Sizes.Sector, s.Length));
+            byte[] header = StreamUtilities.ReadExact(s, (int)Math.Min(Sizes.Sector, s.Length));
             if (header.Length < Sizes.Sector ||
                 EndianUtilities.ToUInt32LittleEndian(header, 0) != HostedSparseExtentHeader.VmdkMagicNumber)
             {

--- a/Library/DiscUtils.Vmdk/ServerSparseExtentStream.cs
+++ b/Library/DiscUtils.Vmdk/ServerSparseExtentStream.cs
@@ -40,7 +40,7 @@ namespace DiscUtils.Vmdk
             _ownsParentDiskStream = ownsParentDiskStream;
 
             file.Position = 0;
-            byte[] firstSectors = StreamUtilities.ReadFully(file, Sizes.Sector * 4);
+            byte[] firstSectors = StreamUtilities.ReadExact(file, Sizes.Sector * 4);
             _serverHeader = ServerSparseExtentHeader.Read(firstSectors, 0);
             _header = _serverHeader;
 
@@ -110,7 +110,7 @@ namespace DiscUtils.Vmdk
             _parentDiskStream.Position = _diskOffset +
                                          (grain + _header.NumGTEsPerGT * grainTable) * _header.GrainSize *
                                          Sizes.Sector;
-            byte[] content = StreamUtilities.ReadFully(_parentDiskStream, (int)(_header.GrainSize * Sizes.Sector * count));
+            byte[] content = StreamUtilities.ReadExact(_parentDiskStream, (int)(_header.GrainSize * Sizes.Sector * count));
             _fileStream.Position = grainStartPos;
             _fileStream.Write(content, 0, content.Length);
 

--- a/Library/DiscUtils.Wim/FileResourceStream.cs
+++ b/Library/DiscUtils.Wim/FileResourceStream.cs
@@ -67,7 +67,7 @@ namespace DiscUtils.Wim
             _chunkLength = new long[numChunks];
             for (int i = 1; i < numChunks; ++i)
             {
-                _chunkOffsets[i] = EndianUtilities.ToUInt32LittleEndian(StreamUtilities.ReadFully(_baseStream, 4), 0);
+                _chunkOffsets[i] = EndianUtilities.ToUInt32LittleEndian(StreamUtilities.ReadExact(_baseStream, 4), 0);
                 _chunkLength[i - 1] = _chunkOffsets[i] - _chunkOffsets[i - 1];
             }
 

--- a/Library/DiscUtils.Wim/WimFile.cs
+++ b/Library/DiscUtils.Wim/WimFile.cs
@@ -45,7 +45,7 @@ namespace DiscUtils.Wim
         {
             _fileStream = stream;
 
-            byte[] buffer = StreamUtilities.ReadFully(stream, 512);
+            byte[] buffer = StreamUtilities.ReadExact(stream, 512);
             _fileHeader = new FileHeader();
             _fileHeader.Read(buffer, 0);
 
@@ -129,7 +129,7 @@ namespace DiscUtils.Wim
                 long numRead = 0;
                 while (numRead < s.Length)
                 {
-                    byte[] resBuffer = StreamUtilities.ReadFully(s, ResourceInfo.Size);
+                    byte[] resBuffer = StreamUtilities.ReadExact(s, ResourceInfo.Size);
                     numRead += ResourceInfo.Size;
 
                     ResourceInfo info = new ResourceInfo();
@@ -191,7 +191,7 @@ namespace DiscUtils.Wim
                 long numRead = 0;
                 while (numRead < s.Length)
                 {
-                    byte[] resBuffer = StreamUtilities.ReadFully(s, ResourceInfo.Size);
+                    byte[] resBuffer = StreamUtilities.ReadExact(s, ResourceInfo.Size);
                     numRead += ResourceInfo.Size;
 
                     ResourceInfo info = new ResourceInfo();

--- a/Library/DiscUtils.Xfs/AllocationGroup.cs
+++ b/Library/DiscUtils.Xfs/AllocationGroup.cs
@@ -50,7 +50,7 @@ namespace DiscUtils.Xfs
             var superblock = context.SuperBlock;
             FreeBlockInfo = new AllocationGroupFreeBlockInfo(superblock);
             data.Position = offset + superblock.SectorSize;
-            var agfData = StreamUtilities.ReadFully(data, FreeBlockInfo.Size); 
+            var agfData = StreamUtilities.ReadExact(data, FreeBlockInfo.Size); 
             FreeBlockInfo.ReadFrom(agfData, 0);
             if (FreeBlockInfo.Magic != AllocationGroupFreeBlockInfo.AgfMagic)
             {
@@ -59,7 +59,7 @@ namespace DiscUtils.Xfs
 
             InodeBtreeInfo = new AllocationGroupInodeBtreeInfo(superblock);
             data.Position = offset + superblock.SectorSize * 2;
-            var agiData = StreamUtilities.ReadFully(data, InodeBtreeInfo.Size);
+            var agiData = StreamUtilities.ReadExact(data, InodeBtreeInfo.Size);
 
             InodeBtreeInfo.ReadFrom(agiData, 0);
             if (InodeBtreeInfo.Magic != AllocationGroupInodeBtreeInfo.AgiMagic)
@@ -81,7 +81,7 @@ namespace DiscUtils.Xfs
         {
             var offset = Offset + ((long)inode.AgBlock*Context.SuperBlock.Blocksize) + ((long)inode.BlockOffset * Context.SuperBlock.InodeSize);
             Context.RawStream.Position = offset;
-            var data = StreamUtilities.ReadFully(Context.RawStream, (int) Context.SuperBlock.InodeSize);
+            var data = StreamUtilities.ReadExact(Context.RawStream, (int) Context.SuperBlock.InodeSize);
             inode.ReadFrom(data, 0);
         }
     }

--- a/Library/DiscUtils.Xfs/AllocationGroupInodeBtreeInfo.cs
+++ b/Library/DiscUtils.Xfs/AllocationGroupInodeBtreeInfo.cs
@@ -80,7 +80,7 @@ namespace DiscUtils.Xfs
         /// Deprecated and not used, it's always set to NULL (-1).
         /// </summary>
         [Obsolete]
-        public int DirInode { get; private set; }
+        public int DirInode => -1;
 
         /// <summary>
         /// Hash table of unlinked (deleted) inodes that are still being referenced.
@@ -122,7 +122,6 @@ namespace DiscUtils.Xfs
             Level = EndianUtilities.ToUInt32BigEndian(buffer, offset + 0x18);
             FreeCount = EndianUtilities.ToUInt32BigEndian(buffer, offset + 0x1c);
             NewInode = EndianUtilities.ToUInt32BigEndian(buffer, offset + 0x20);
-            DirInode = EndianUtilities.ToInt32BigEndian(buffer, offset + 0x24);
             Unlinked = new int[64];
             for (int i = 0; i < Unlinked.Length; i++)
             {
@@ -149,7 +148,7 @@ namespace DiscUtils.Xfs
             {
                 RootInodeBtree = new BTreeInodeNode(SbVersion);
             }
-            var buffer = StreamUtilities.ReadFully(data, (int) context.SuperBlock.Blocksize);
+            var buffer = StreamUtilities.ReadExact(data, (int) context.SuperBlock.Blocksize);
             RootInodeBtree.ReadFrom(buffer, 0);
         }
 

--- a/Library/DiscUtils.Xfs/BTreeExtentNode.cs
+++ b/Library/DiscUtils.Xfs/BTreeExtentNode.cs
@@ -75,7 +75,7 @@ namespace DiscUtils.Xfs
                 }
                 var data = context.RawStream;
                 data.Position = Extent.GetOffset(context, Pointer[i]);
-                var buffer = StreamUtilities.ReadFully(data, (int)context.SuperBlock.Blocksize);
+                var buffer = StreamUtilities.ReadExact(data, (int)context.SuperBlock.Blocksize);
                 child.ReadFrom(buffer, 0);
                 if (child.Magic != BtreeMagic)
                 {

--- a/Library/DiscUtils.Xfs/BTreeExtentRoot.cs
+++ b/Library/DiscUtils.Xfs/BTreeExtentRoot.cs
@@ -87,7 +87,7 @@ namespace DiscUtils.Xfs
                 }
                 var data = context.RawStream;
                 data.Position = Extent.GetOffset(context, Pointer[i]);
-                var buffer = StreamUtilities.ReadFully(data, (int)context.SuperBlock.Blocksize);
+                var buffer = StreamUtilities.ReadExact(data, (int)context.SuperBlock.Blocksize);
                 child.ReadFrom(buffer, 0);
                 if (child.Magic != BTreeExtentHeader.BtreeMagic)
                 {

--- a/Library/DiscUtils.Xfs/BTreeInodeNode.cs
+++ b/Library/DiscUtils.Xfs/BTreeInodeNode.cs
@@ -78,8 +78,10 @@ namespace DiscUtils.Xfs
                     child = new BTreeInodeNode(base.SbVersion);
                 }
                 var data = ag.Context.RawStream;
+
                 data.Position = ((long)Pointer[i] * ag.Context.SuperBlock.Blocksize) + ag.Offset;
-                var buffer = StreamUtilities.ReadFully(data, (int)ag.Context.SuperBlock.Blocksize);
+                var buffer = StreamUtilities.ReadExact(data, (int)ag.Context.SuperBlock.Blocksize);
+
                 child.ReadFrom(buffer, 0);
                 child.LoadBtree(ag);
                 Children.Add(Keys[i], child);

--- a/Library/DiscUtils.Xfs/Extent.cs
+++ b/Library/DiscUtils.Xfs/Extent.cs
@@ -80,7 +80,7 @@ namespace DiscUtils.Xfs
         public byte[] GetData(Context context, long offset, uint count)
         {
             context.RawStream.Position = GetOffset(context) + offset;
-            return StreamUtilities.ReadFully(context.RawStream, (int) count);
+            return StreamUtilities.ReadExact(context.RawStream, (int) count);
         }
 
         /// <inheritdoc />

--- a/Library/DiscUtils.Xfs/Symlink.cs
+++ b/Library/DiscUtils.Xfs/Symlink.cs
@@ -42,8 +42,10 @@ namespace DiscUtils.Xfs
                 {
                     throw new IOException("invalid Inode format for symlink");
                 }
+
                 IBuffer content = FileContent;
-                byte[] data = StreamUtilities.ReadFully(content, 0, (int)Inode.Length);
+                byte[] data = StreamUtilities.ReadExact(content, 0, (int)Inode.Length);
+
                 return Context.Options.FileNameEncoding.GetString(data, 0, data.Length).Replace('/', '\\');
             }
         }

--- a/Library/DiscUtils.Xfs/VfsXfsFileSystem.cs
+++ b/Library/DiscUtils.Xfs/VfsXfsFileSystem.cs
@@ -38,7 +38,7 @@ namespace DiscUtils.Xfs
             :base(new XfsFileSystemOptions(parameters))
         {
             stream.Position = 0;
-            byte[] superblockData = StreamUtilities.ReadFully(stream, 264);
+            byte[] superblockData = StreamUtilities.ReadExact(stream, 264);
 
             SuperBlock superblock = new SuperBlock();
             superblock.ReadFrom(superblockData, 0);

--- a/Library/DiscUtils.Xfs/XfsFileSystem.cs
+++ b/Library/DiscUtils.Xfs/XfsFileSystem.cs
@@ -69,7 +69,7 @@ namespace DiscUtils.Xfs
             }
 
             stream.Position = 0;
-            byte[] superblockData = StreamUtilities.ReadFully(stream, 264);
+            byte[] superblockData = StreamUtilities.ReadExact(stream, 264);
 
             SuperBlock superblock = new SuperBlock();
             superblock.ReadFrom(superblockData, 0);

--- a/Tests/LibraryTests/Buffers/BufferTest.cs
+++ b/Tests/LibraryTests/Buffers/BufferTest.cs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2008-2011, Kenneth Bell
+// Copyright (c) 2017, Glen Parker
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,44 +20,29 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using System;
-using System.IO;
+using DiscUtils.Streams;
+using System.Linq;
+using Xunit;
 
-namespace DiscUtils.Streams
+namespace LibraryTests.Buffers
 {
-    public class BigEndianDataReader : DataReader
+    public class BufferTest
     {
-        public BigEndianDataReader(Stream stream)
-            : base(stream) {}
-
-        public override ushort ReadUInt16()
+        [Fact]
+        public void SparseMemoryBufferClear()
         {
-            ReadToBuffer(sizeof(UInt16));
-            return EndianUtilities.ToUInt16BigEndian(_buffer, 0);
-        }
+            SparseMemoryBuffer memoryBuffer = new SparseMemoryBuffer(10);
+            byte[] buffer = new byte[20];
 
-        public override int ReadInt32()
-        {
-            ReadToBuffer(sizeof(Int32));
-            return EndianUtilities.ToInt32BigEndian(_buffer, 0);
-        }
+            memoryBuffer.Write(0, buffer, 0, 20);
+            Assert.Equal(2, memoryBuffer.AllocatedChunks.Count());
+            memoryBuffer.Clear(0, 20);
+            Assert.Equal(0, memoryBuffer.AllocatedChunks.Count());
 
-        public override uint ReadUInt32()
-        {
-            ReadToBuffer(sizeof(UInt32));
-            return EndianUtilities.ToUInt32BigEndian(_buffer, 0);
-        }
-
-        public override long ReadInt64()
-        {
-            ReadToBuffer(sizeof(Int64));
-            return EndianUtilities.ToInt64BigEndian(_buffer, 0);
-        }
-
-        public override ulong ReadUInt64()
-        {
-            ReadToBuffer(sizeof(UInt64));
-            return EndianUtilities.ToUInt64BigEndian(_buffer, 0);
+            memoryBuffer.Write(0, buffer, 0, 15);
+            Assert.Equal(2, memoryBuffer.AllocatedChunks.Count());
+            memoryBuffer.Clear(0, 15);
+            Assert.Equal(1, memoryBuffer.AllocatedChunks.Count());
         }
     }
 }

--- a/Tests/LibraryTests/Streams/BuiltStreamTest.cs
+++ b/Tests/LibraryTests/Streams/BuiltStreamTest.cs
@@ -20,7 +20,6 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using System;
 using System.Collections.Generic;
 using DiscUtils.Streams;
 using Xunit;

--- a/Tests/LibraryTests/Vdi/StreamTest.cs
+++ b/Tests/LibraryTests/Vdi/StreamTest.cs
@@ -22,7 +22,6 @@
 
 using System;
 using System.IO;
-using DiscUtils;
 using DiscUtils.Streams;
 using DiscUtils.Vdi;
 using Xunit;

--- a/Utilities/DiscUtils.Diagnostics/Properties/AssemblyInfo.cs
+++ b/Utilities/DiscUtils.Diagnostics/Properties/AssemblyInfo.cs
@@ -11,7 +11,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("DiscUtils")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: CLSCompliant(true)]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 


### PR DESCRIPTION
Optimize SparseMemoryBuffer.Clear() to never create new buffers, and remove buffers that would otherwise be fully zeroed.
Create distinction between reading from a stream/buffer an exact number of bytes, vs a maximmum number of bytes (up to EOF).
When reading an exact number of bytes from a stream/buffer, throw EndOfStreamException (not IOException) on premature EOF.
In the binary readers and writers, use a static buffer for integer conversions (be nice to the GC).
Fix a Deprecated warning, and actually do what the warning says it does.
Remove two instances of [assembly: CLSCompliant(true)] which appear to be a mistake.