### PR TITLE
Expose PhysicalVolumeInfo & PartitionInfo

### DIFF
--- a/Library/DiscUtils.Core/LogicalVolumeInfo.cs
+++ b/Library/DiscUtils.Core/LogicalVolumeInfo.cs
@@ -102,6 +102,11 @@ namespace DiscUtils
         /// Gets the status of the logical volume, indicating volume health.
         /// </summary>
         public LogicalVolumeStatus Status { get; }
+        
+        /// <summary>
+        /// Gets the underlying physical volume info
+        /// </summary>
+        public PhysicalVolumeInfo PhysicalVolume { get { return _physicalVol; } }
 
         /// <summary>
         /// Opens a stream with access to the content of the logical volume.

--- a/Library/DiscUtils.Core/PhysicalVolumeInfo.cs
+++ b/Library/DiscUtils.Core/PhysicalVolumeInfo.cs
@@ -150,7 +150,7 @@ namespace DiscUtils
         /// <summary>
         /// Gets the underlying partition (if any).
         /// </summary>
-        internal PartitionInfo Partition { get; }
+        public PartitionInfo Partition { get; }
 
         /// <summary>
         /// Gets the unique identity of the physical partition, if known.


### PR DESCRIPTION
Makes the PhysicalVolumeInfo and PartitionInfo public, to check the partition type of a logical volume. We currently use this to filter [MSR](https://en.wikipedia.org/wiki/Microsoft_Reserved_Partition) partitions.