### PR TITLE
Ext bugfix & support for unclean journal

### DIFF
--- a/Library/DiscUtils.Ext/SuperBlock.cs
+++ b/Library/DiscUtils.Ext/SuperBlock.cs
@@ -191,10 +191,10 @@ namespace DiscUtils.Ext
             WantExtraInodeSize = EndianUtilities.ToUInt16LittleEndian(buffer, offset + 350);
             Flags = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 352);
             RaidStride = EndianUtilities.ToUInt16LittleEndian(buffer, offset + 356);
-            MultiMountProtectionInterval = EndianUtilities.ToUInt16LittleEndian(buffer, offset + 258);
-            MultiMountProtectionBlock = EndianUtilities.ToUInt64LittleEndian(buffer, offset + 260);
-            RaidStripeWidth = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 268);
-            LogGroupsPerFlex = buffer[offset + 272];
+            MultiMountProtectionInterval = EndianUtilities.ToUInt16LittleEndian(buffer, offset + 358);
+            MultiMountProtectionBlock = EndianUtilities.ToUInt64LittleEndian(buffer, offset + 360);
+            RaidStripeWidth = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 368);
+            LogGroupsPerFlex = buffer[offset + 372];
 
             OverheadBlocksCount = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 584);
 

--- a/Library/DiscUtils.Ext/VfsExtFileSystem.cs
+++ b/Library/DiscUtils.Ext/VfsExtFileSystem.cs
@@ -31,7 +31,9 @@ namespace DiscUtils.Ext
         internal const IncompatibleFeatures SupportedIncompatibleFeatures =
             IncompatibleFeatures.FileType
             | IncompatibleFeatures.FlexBlockGroups
-            | IncompatibleFeatures.Extents;
+            | IncompatibleFeatures.Extents
+            | IncompatibleFeatures.NeedsRecovery
+            | IncompatibleFeatures.SixtyFourBit;
 
         private readonly BlockGroup[] _blockGroups;
 


### PR DESCRIPTION
Add support for opening ext filesystems with an unclean journal (as the summary states, it's save for reading and ext is always readonly).

Also fixes a wrong offset for some superblock fields (which looks like an old typo) and adds the missing incompat feature flag for ext4 64bit support.