### PR TITLE
Nfs: Add read/write support for most objects, unit tests

### DIFF
--- a/Library/DiscUtils.Nfs/HashCode.cs
+++ b/Library/DiscUtils.Nfs/HashCode.cs
@@ -1,0 +1,423 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*
+
+The xxHash32 implementation is based on the code published by Yann Collet:
+https://raw.githubusercontent.com/Cyan4973/xxHash/5c174cfa4e45a42f94082dc0d4539b39696afea1/xxhash.c
+
+  xxHash - Fast Hash algorithm
+  Copyright (C) 2012-2016, Yann Collet
+  
+  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+  
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  
+  * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following disclaimer
+  in the documentation and/or other materials provided with the
+  distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  
+  You can contact the author at :
+  - xxHash homepage: http://www.xxhash.com
+  - xxHash source repository : https://github.com/Cyan4973/xxHash
+
+*/
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    // xxHash32 is used for the hash code.
+    // https://github.com/Cyan4973/xxHash
+
+    public struct HashCode
+    {
+        private static readonly uint s_seed = GenerateGlobalSeed();
+
+        private const uint Prime1 = 2654435761U;
+        private const uint Prime2 = 2246822519U;
+        private const uint Prime3 = 3266489917U;
+        private const uint Prime4 = 668265263U;
+        private const uint Prime5 = 374761393U;
+
+        private uint _v1, _v2, _v3, _v4;
+        private uint _queue1, _queue2, _queue3;
+        private uint _length;
+
+        private static uint GenerateGlobalSeed()
+        {
+            var random = new Random();
+            return (uint)random.Next();
+        }
+
+        public static int Combine<T1>(T1 value1)
+        {
+            // Provide a way of diffusing bits from something with a limited
+            // input hash space. For example, many enums only have a few
+            // possible hashes, only using the bottom few bits of the code. Some
+            // collections are built on the assumption that hashes are spread
+            // over a larger space, so diffusing the bits may help the
+            // collection work more efficiently.
+
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+
+            uint hash = MixEmptyState();
+            hash += 4;
+
+            hash = QueueRound(hash, hc1);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        public static int Combine<T1, T2>(T1 value1, T2 value2)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+
+            uint hash = MixEmptyState();
+            hash += 8;
+
+            hash = QueueRound(hash, hc1);
+            hash = QueueRound(hash, hc2);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+
+            uint hash = MixEmptyState();
+            hash += 12;
+
+            hash = QueueRound(hash, hc1);
+            hash = QueueRound(hash, hc2);
+            hash = QueueRound(hash, hc3);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        public static int Combine<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 16;
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        public static int Combine<T1, T2, T3, T4, T5>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+            var hc5 = (uint)(value5?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 20;
+
+            hash = QueueRound(hash, hc5);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        public static int Combine<T1, T2, T3, T4, T5, T6>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+            var hc5 = (uint)(value5?.GetHashCode() ?? 0);
+            var hc6 = (uint)(value6?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 24;
+
+            hash = QueueRound(hash, hc5);
+            hash = QueueRound(hash, hc6);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        public static int Combine<T1, T2, T3, T4, T5, T6, T7>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+            var hc5 = (uint)(value5?.GetHashCode() ?? 0);
+            var hc6 = (uint)(value6?.GetHashCode() ?? 0);
+            var hc7 = (uint)(value7?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 28;
+
+            hash = QueueRound(hash, hc5);
+            hash = QueueRound(hash, hc6);
+            hash = QueueRound(hash, hc7);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        public static int Combine<T1, T2, T3, T4, T5, T6, T7, T8>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+            var hc5 = (uint)(value5?.GetHashCode() ?? 0);
+            var hc6 = (uint)(value6?.GetHashCode() ?? 0);
+            var hc7 = (uint)(value7?.GetHashCode() ?? 0);
+            var hc8 = (uint)(value8?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            v1 = Round(v1, hc5);
+            v2 = Round(v2, hc6);
+            v3 = Round(v3, hc7);
+            v4 = Round(v4, hc8);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 32;
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        private static uint Rol(uint value, int count)
+            => (value << count) | (value >> (32 - count));
+
+        private static void Initialize(out uint v1, out uint v2, out uint v3, out uint v4)
+        {
+            v1 = s_seed + Prime1 + Prime2;
+            v2 = s_seed + Prime2;
+            v3 = s_seed;
+            v4 = s_seed - Prime1;
+        }
+
+        private static uint Round(uint hash, uint input)
+        {
+            hash += input * Prime2;
+            hash = Rol(hash, 13);
+            hash *= Prime1;
+            return hash;
+        }
+
+        private static uint QueueRound(uint hash, uint queuedValue)
+        {
+            hash += queuedValue * Prime3;
+            return Rol(hash, 17) * Prime4;
+        }
+
+        private static uint MixState(uint v1, uint v2, uint v3, uint v4)
+        {
+            return Rol(v1, 1) + Rol(v2, 7) + Rol(v3, 12) + Rol(v4, 18);
+        }
+
+        private static uint MixEmptyState()
+        {
+            return s_seed + Prime5;
+        }
+
+        private static uint MixFinal(uint hash)
+        {
+            hash ^= hash >> 15;
+            hash *= Prime2;
+            hash ^= hash >> 13;
+            hash *= Prime3;
+            hash ^= hash >> 16;
+            return hash;
+        }
+
+        public void Add<T>(T value)
+        {
+            Add(value?.GetHashCode() ?? 0);
+        }
+
+        public void Add<T>(T value, IEqualityComparer<T> comparer)
+        {
+            Add(comparer != null ? comparer.GetHashCode(value) : (value?.GetHashCode() ?? 0));
+        }
+
+        private void Add(int value)
+        {
+            // The original xxHash works as follows:
+            // 0. Initialize immediately. We can't do this in a struct (no
+            //    default ctor).
+            // 1. Accumulate blocks of length 16 (4 uints) into 4 accumulators.
+            // 2. Accumulate remaining blocks of length 4 (1 uint) into the
+            //    hash.
+            // 3. Accumulate remaining blocks of length 1 into the hash.
+
+            // There is no need for #3 as this type only accepts ints. _queue1,
+            // _queue2 and _queue3 are basically a buffer so that when
+            // ToHashCode is called we can execute #2 correctly.
+
+            // We need to initialize the xxHash32 state (_v1 to _v4) lazily (see
+            // #0) nd the last place that can be done if you look at the
+            // original code is just before the first block of 16 bytes is mixed
+            // in. The xxHash32 state is never used for streams containing fewer
+            // than 16 bytes.
+
+            // To see what's really going on here, have a look at the Combine
+            // methods.
+
+            var val = (uint)value;
+
+            // Storing the value of _length locally shaves of quite a few bytes
+            // in the resulting machine code.
+            uint previousLength = _length++;
+            uint position = previousLength % 4;
+
+            // Switch can't be inlined.
+
+            if (position == 0)
+                _queue1 = val;
+            else if (position == 1)
+                _queue2 = val;
+            else if (position == 2)
+                _queue3 = val;
+            else // position == 3
+            {
+                if (previousLength == 3)
+                    Initialize(out _v1, out _v2, out _v3, out _v4);
+
+                _v1 = Round(_v1, _queue1);
+                _v2 = Round(_v2, _queue2);
+                _v3 = Round(_v3, _queue3);
+                _v4 = Round(_v4, val);
+            }
+        }
+
+        public int ToHashCode()
+        {
+            // Storing the value of _length locally shaves of quite a few bytes
+            // in the resulting machine code.
+            uint length = _length;
+
+            // position refers to the *next* queue position in this method, so
+            // position == 1 means that _queue1 is populated; _queue2 would have
+            // been populated on the next call to Add.
+            uint position = length % 4;
+
+            // If the length is less than 4, _v1 to _v4 don't contain anything
+            // yet. xxHash32 treats this differently.
+
+            uint hash = length < 4 ? MixEmptyState() : MixState(_v1, _v2, _v3, _v4);
+
+            // _length is incremented once per Add(Int32) and is therefore 4
+            // times too small (xxHash length is in bytes, not ints).
+
+            hash += length * 4;
+
+            // Mix what remains in the queue
+
+            // Switch can't be inlined right now, so use as few branches as
+            // possible by manually excluding impossible scenarios (position > 1
+            // is always false if position is not > 0).
+            if (position > 0)
+            {
+                hash = QueueRound(hash, _queue1);
+                if (position > 1)
+                {
+                    hash = QueueRound(hash, _queue2);
+                    if (position > 2)
+                        hash = QueueRound(hash, _queue3);
+                }
+            }
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+#pragma warning disable 0809
+        // Obsolete member 'memberA' overrides non-obsolete member 'memberB'. 
+        // Disallowing GetHashCode and Equals is by design
+
+        // * We decided to not override GetHashCode() to produce the hash code 
+        //   as this would be weird, both naming-wise as well as from a
+        //   behavioral standpoint (GetHashCode() should return the object's
+        //   hash code, not the one being computed).
+
+        // * Even though ToHashCode() can be called safely multiple times on
+        //   this implementation, it is not part of the contract. If the
+        //   implementation has to change in the future we don't want to worry
+        //   about people who might have incorrectly used this type.
+
+        [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.", error: true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => throw new NotSupportedException();
+
+        [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes.", error: true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => throw new NotSupportedException();
+#pragma warning restore 0809
+    }
+}

--- a/Library/DiscUtils.Nfs/Nfs3.cs
+++ b/Library/DiscUtils.Nfs/Nfs3.cs
@@ -224,14 +224,14 @@ namespace DiscUtils.Nfs
             throw new RpcException(reply.Header.ReplyHeader);
         }
 
-        public Nfs3ReadDirPlusResult ReadDirPlus(Nfs3FileHandle dir, ulong cookie, byte[] cookieVerifier, uint dirCount,
+        public Nfs3ReadDirPlusResult ReadDirPlus(Nfs3FileHandle dir, ulong cookie, ulong cookieVerifier, uint dirCount,
                                                  uint maxCount)
         {
             MemoryStream ms = new MemoryStream();
             XdrDataWriter writer = StartCallMessage(ms, _client.Credentials, NfsProc3.Readdirplus);
             dir.Write(writer);
             writer.Write(cookie);
-            writer.WriteBytes(cookieVerifier ?? new byte[CookieVerifierSize]);
+            writer.Write(cookieVerifier);
             writer.Write(dirCount);
             writer.Write(maxCount);
 

--- a/Library/DiscUtils.Nfs/Nfs3Client.cs
+++ b/Library/DiscUtils.Nfs/Nfs3Client.cs
@@ -244,7 +244,7 @@ namespace DiscUtils.Nfs
         internal IEnumerable<Nfs3DirectoryEntry> ReadDirectory(Nfs3FileHandle parent, bool silentFail)
         {
             ulong cookie = 0;
-            byte[] cookieVerifier = null;
+            ulong cookieVerifier = 0;
 
             Nfs3ReadDirPlusResult result;
             do

--- a/Library/DiscUtils.Nfs/Nfs3DirectoryEntry.cs
+++ b/Library/DiscUtils.Nfs/Nfs3DirectoryEntry.cs
@@ -20,6 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     internal class Nfs3DirectoryEntry
@@ -40,6 +42,10 @@ namespace DiscUtils.Nfs
             }
         }
 
+        public Nfs3DirectoryEntry()
+        {
+        }
+
         public ulong Cookie { get; set; }
 
         public Nfs3FileAttributes FileAttributes { get; set; }
@@ -49,5 +55,48 @@ namespace DiscUtils.Nfs
         public ulong FileId { get; set; }
 
         public string Name { get; set; }
+
+        public void Write(XdrDataWriter writer)
+        {
+            writer.Write(FileId);
+            writer.Write(Name);
+            writer.Write(Cookie);
+
+            writer.Write(FileAttributes != null);
+            if (FileAttributes != null)
+            {
+                FileAttributes.Write(writer);
+            }
+
+            writer.Write(FileHandle != null);
+            if (FileHandle != null)
+            {
+                FileHandle.Write(writer);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3DirectoryEntry);
+        }
+
+        public bool Equals(Nfs3DirectoryEntry other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Cookie == Cookie
+                && object.Equals(other.FileAttributes, FileAttributes)
+                && object.Equals(other.FileHandle, FileHandle)
+                && other.FileId == FileId
+                && object.Equals(other.Name, Name);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Cookie, FileAttributes, FileHandle, FileId, Name);
+        }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3FileAttributes.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileAttributes.cs
@@ -20,6 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     internal class Nfs3FileAttributes
@@ -39,6 +41,10 @@ namespace DiscUtils.Nfs
         public Nfs3FileType Type;
         public uint Uid;
 
+        public Nfs3FileAttributes()
+        {
+        }
+
         public Nfs3FileAttributes(XdrDataReader reader)
         {
             Type = (Nfs3FileType)reader.ReadInt32();
@@ -55,6 +61,59 @@ namespace DiscUtils.Nfs
             AccessTime = new Nfs3FileTime(reader);
             ModifyTime = new Nfs3FileTime(reader);
             ChangeTime = new Nfs3FileTime(reader);
+        }
+
+        public void Write(XdrDataWriter writer)
+        {
+            writer.Write((int)Type);
+            writer.Write((int)Mode);
+            writer.Write(LinkCount);
+            writer.Write(Uid);
+            writer.Write(Gid);
+            writer.Write(Size);
+            writer.Write(BytesUsed);
+            writer.Write(RdevMajor);
+            writer.Write(RdevMinor);
+            writer.Write(FileSystemId);
+            writer.Write(FileId);
+            AccessTime.Write(writer);
+            ModifyTime.Write(writer);
+            ChangeTime.Write(writer);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return base.Equals(obj);
+        }
+
+        public bool Equals(Nfs3FileAttributes other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Type == Type
+                && other.Mode == Mode
+                && other.LinkCount == LinkCount
+                && other.Uid == Uid
+                && other.Gid == Gid
+                && other.Size == Size
+                && other.BytesUsed == BytesUsed
+                && other.RdevMajor == RdevMajor
+                && other.RdevMinor == RdevMinor
+                && other.FileSystemId == FileSystemId
+                && other.FileId == FileId
+                && object.Equals(other.AccessTime, AccessTime)
+                && object.Equals(other.ModifyTime, ModifyTime)
+                && object.Equals(other.ChangeTime, ChangeTime);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                HashCode.Combine(Type, Mode, LinkCount, Uid, Gid, Size, BytesUsed, RdevMajor),
+                RdevMinor, FileSystemId, FileId, AccessTime, ModifyTime, ChangeTime);
         }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3FileAttributes.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileAttributes.cs
@@ -83,7 +83,7 @@ namespace DiscUtils.Nfs
 
         public override bool Equals(object obj)
         {
-            return base.Equals(obj);
+            return Equals(obj as Nfs3FileAttributes);
         }
 
         public bool Equals(Nfs3FileAttributes other)

--- a/Library/DiscUtils.Nfs/Nfs3FileHandle.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileHandle.cs
@@ -26,6 +26,10 @@ namespace DiscUtils.Nfs
 {
     internal sealed class Nfs3FileHandle : IEquatable<Nfs3FileHandle>, IComparable<Nfs3FileHandle>
     {
+        public Nfs3FileHandle()
+        {
+        }
+
         internal Nfs3FileHandle(XdrDataReader reader)
         {
             Value = reader.ReadBuffer(Nfs3Mount.MaxFileHandleSize);

--- a/Library/DiscUtils.Nfs/Nfs3FileSystemInfo.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileSystemInfo.cs
@@ -127,7 +127,7 @@ namespace DiscUtils.Nfs
 
         public override bool Equals(object obj)
         {
-            return base.Equals(obj);
+            return Equals(obj as Nfs3FileSystemInfo);
         }
 
         public bool Equals(Nfs3FileSystemInfo other)

--- a/Library/DiscUtils.Nfs/Nfs3FileSystemInfo.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileSystemInfo.cs
@@ -20,6 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     internal sealed class Nfs3FileSystemInfo
@@ -38,24 +40,120 @@ namespace DiscUtils.Nfs
             FileSystemProperties = (Nfs3FileSystemProperties)reader.ReadInt32();
         }
 
+        public Nfs3FileSystemInfo()
+        {
+        }
+
+        /// <summary>
+        /// The preferred size of a READDIR request.
+        /// </summary>
         public uint DirectoryPreferredBytes { get; set; }
 
+        /// <summary>
+        /// A bit mask of file system properties.
+        /// </summary>
         public Nfs3FileSystemProperties FileSystemProperties { get; set; }
 
+        /// <summary>
+        /// The maximum size of a file on the file system.
+        /// </summary>
         public long MaxFileSize { get; set; }
 
+        /// <summary>
+        /// The maximum size in bytes of a READ request supported
+        /// by the server. Any READ with a number greater than
+        /// rtmax will result in a short read of rtmax bytes or
+        /// less.
+        /// </summary>
         public uint ReadMaxBytes { get; set; }
 
+        /// <summary>
+        /// The suggested multiple for the size of a READ request.
+        /// </summary>
         public uint ReadMultipleSize { get; set; }
 
+        /// <summary>
+        /// The preferred size of a READ request. This should be
+        /// the same as rtmax unless there is a clear benefit in
+        /// performance or efficiency.
+        /// </summary>
         public uint ReadPreferredBytes { get; set; }
 
+        /// <summary>
+        /// The server time granularity. When setting a file time
+        /// using SETATTR, the server guarantees only to preserve
+        /// times to this accuracy. If this is {0, 1}, the server
+        /// can support nanosecond times, {0, 1000000}
+        /// denotes millisecond precision, and {1, 0} indicates that times
+        /// are accurate only to the nearest second.
+        /// </summary>
         public Nfs3FileTime TimePrecision { get; set; }
 
+        /// <summary>
+        /// The maximum size of a WRITE request supported by the
+        /// server. In general, the client is limited by wtmax
+        /// since there is no guarantee that a server can handle a
+        /// larger write. Any WRITE with a count greater than wtmax
+        /// will result in a short write of at most wtmax bytes.
+        /// </summary>
         public uint WriteMaxBytes { get; set; }
 
+        /// <summary>
+        /// The suggested multiple for the size of a WRITE
+        /// request.
+        /// </summary>
         public uint WriteMultipleSize { get; set; }
 
+        /// <summary>
+        /// The preferred size of a WRITE request. This should be
+        /// the same as wtmax unless there is a clear benefit in
+        /// performance or efficiency.
+        /// </summary>
         public uint WritePreferredBytes { get; set; }
+
+        public void Write(XdrDataWriter writer)
+        {
+            writer.Write(ReadMaxBytes);
+            writer.Write(ReadPreferredBytes);
+            writer.Write(ReadMultipleSize);
+            writer.Write(WriteMaxBytes);
+            writer.Write(WritePreferredBytes);
+            writer.Write(WriteMultipleSize);
+            writer.Write(DirectoryPreferredBytes);
+            writer.Write(MaxFileSize);
+            TimePrecision.Write(writer);
+            writer.Write((int)FileSystemProperties);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return base.Equals(obj);
+        }
+
+        public bool Equals(Nfs3FileSystemInfo other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.ReadMaxBytes == ReadMaxBytes
+                && other.ReadPreferredBytes == ReadPreferredBytes
+                && other.ReadMultipleSize == ReadMultipleSize
+                && other.WriteMaxBytes == WriteMaxBytes
+                && other.WritePreferredBytes == WritePreferredBytes
+                && other.WriteMultipleSize == WriteMultipleSize
+                && other.DirectoryPreferredBytes == DirectoryPreferredBytes
+                && other.MaxFileSize == MaxFileSize
+                && object.Equals(other.TimePrecision, TimePrecision)
+                && other.FileSystemProperties == FileSystemProperties;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                HashCode.Combine(ReadMaxBytes, ReadPreferredBytes, ReadMultipleSize, WriteMaxBytes, WritePreferredBytes, WriteMultipleSize, DirectoryPreferredBytes, MaxFileSize),
+                TimePrecision, FileSystemProperties);
+        }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3FileSystemInfoResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileSystemInfoResult.cs
@@ -20,6 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     internal class Nfs3FileSystemInfoResult : Nfs3CallResult
@@ -38,8 +40,52 @@ namespace DiscUtils.Nfs
             }
         }
 
+        public Nfs3FileSystemInfoResult()
+        {
+        }
+
         public Nfs3FileSystemInfo FileSystemInfo { get; set; }
 
         public Nfs3FileAttributes PostOpAttributes { get; set; }
+
+        public override void Write(XdrDataWriter writer)
+        {
+            writer.Write((int)Status);
+
+            writer.Write(PostOpAttributes != null);
+
+            if (PostOpAttributes != null)
+            {
+                PostOpAttributes.Write(writer);
+            }
+
+            if (Status == Nfs3Status.Ok)
+            {
+                FileSystemInfo.Write(writer);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3FileSystemInfoResult);
+        }
+
+        public bool Equals(Nfs3FileSystemInfoResult other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Status == Status
+                && object.Equals(other.PostOpAttributes, PostOpAttributes)
+                && other.Status == Status
+                && object.Equals(other.FileSystemInfo, FileSystemInfo);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Status, PostOpAttributes, Status, FileSystemInfo);
+        }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3FileTime.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileTime.cs
@@ -47,6 +47,12 @@ namespace DiscUtils.Nfs
             _nseconds = (uint)(ticks % TicksPerSec * TicksPerNanoSec);
         }
 
+        public Nfs3FileTime(uint seconds, uint nseconds)
+        {
+            _seconds = seconds;
+            _nseconds = nseconds;
+        }
+
         ////public Nfs3FileTime(TimeSpan timeSpan)
         ////{
         ////    long ticks = timeSpan.Ticks;
@@ -68,6 +74,40 @@ namespace DiscUtils.Nfs
         {
             writer.Write(_seconds);
             writer.Write(_nseconds);
+        }
+
+        public static Nfs3FileTime Precision
+        {
+            get
+            {
+                return new Nfs3FileTime(0, 1);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3FileTime);
+        }
+
+        public bool Equals(Nfs3FileTime other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other._seconds == _seconds
+                && other._nseconds == _nseconds;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(_seconds, _nseconds);
+        }
+
+        public override string ToString()
+        {
+            return ToDateTime().ToString();
         }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3LookupResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3LookupResult.cs
@@ -20,10 +20,16 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     internal class Nfs3LookupResult : Nfs3CallResult
     {
+        public Nfs3LookupResult()
+        {
+        }
+
         public Nfs3LookupResult(XdrDataReader reader)
         {
             Status = (Nfs3Status)reader.ReadInt32();
@@ -47,5 +53,52 @@ namespace DiscUtils.Nfs
         public Nfs3FileAttributes ObjectAttributes { get; set; }
 
         public Nfs3FileHandle ObjectHandle { get; set; }
+
+        public override void Write(XdrDataWriter writer)
+        {
+            writer.Write((int)this.Status);
+
+            if (Status == Nfs3Status.Ok)
+            {
+                ObjectHandle.Write(writer);
+
+                writer.Write(ObjectAttributes != null);
+
+                if (ObjectAttributes != null)
+                {
+                    ObjectAttributes.Write(writer);
+                }
+            }
+
+            writer.Write(DirAttributes != null);
+
+            if (DirAttributes != null)
+            {
+                DirAttributes.Write(writer);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3LookupResult);
+        }
+
+        public bool Equals(Nfs3LookupResult other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Status == Status
+                && object.Equals(other.ObjectHandle, ObjectHandle)
+                && object.Equals(other.ObjectAttributes, ObjectAttributes)
+                && object.Equals(other.DirAttributes, DirAttributes);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Status, ObjectHandle, ObjectAttributes, DirAttributes);
+        }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3MountResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3MountResult.cs
@@ -20,25 +20,82 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
 using System.Collections.Generic;
+#if !NET20
+using System.Linq;
+#endif
 
 namespace DiscUtils.Nfs
 {
-    internal sealed class Nfs3MountResult
+    internal sealed class Nfs3MountResult : Nfs3CallResult
     {
-        internal Nfs3MountResult(XdrDataReader reader)
+        public Nfs3MountResult(XdrDataReader reader)
         {
-            FileHandle = new Nfs3FileHandle(reader);
-            int numAuthFlavours = reader.ReadInt32();
-            AuthFlavours = new List<int>(numAuthFlavours);
-            for (int i = 0; i < numAuthFlavours; ++i)
+            Status = (Nfs3Status)reader.ReadInt32();
+
+            if (Status == Nfs3Status.Ok)
             {
-                AuthFlavours.Add(reader.ReadInt32());
+                FileHandle = new Nfs3FileHandle(reader);
+                int numAuthFlavours = reader.ReadInt32();
+                AuthFlavours = new List<RpcAuthFlavour>(numAuthFlavours);
+                for (int i = 0; i < numAuthFlavours; ++i)
+                {
+                    AuthFlavours.Add((RpcAuthFlavour)reader.ReadInt32());
+                }
+            }
+            else
+            {
+                throw new Nfs3Exception(Status);
             }
         }
 
-        public List<int> AuthFlavours { get; set; }
+        public Nfs3MountResult()
+        {
+        }
+
+        public List<RpcAuthFlavour> AuthFlavours { get; set; }
 
         public Nfs3FileHandle FileHandle { get; set; }
+
+        public override void Write(XdrDataWriter writer)
+        {
+            writer.Write((int)Status);
+
+            if (Status == Nfs3Status.Ok)
+            {
+                FileHandle.Write(writer);
+
+                writer.Write(AuthFlavours.Count);
+                for (int i = 0; i < AuthFlavours.Count; i++)
+                {
+                    writer.Write((int)AuthFlavours[i]);
+                }
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3MountResult);
+        }
+
+        public bool Equals(Nfs3MountResult other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Status == Status
+#if !NET20
+                && Enumerable.SequenceEqual(other.AuthFlavours, AuthFlavours)
+#endif
+                && object.Equals(other.FileHandle, FileHandle);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Status, FileHandle, AuthFlavours);
+        }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3ReadResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3ReadResult.cs
@@ -20,6 +20,11 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+#if !NET20
+using System.Linq;
+#endif
+
 namespace DiscUtils.Nfs
 {
     internal class Nfs3ReadResult : Nfs3CallResult
@@ -40,6 +45,10 @@ namespace DiscUtils.Nfs
             }
         }
 
+        public Nfs3ReadResult()
+        {
+        }
+
         public int Count { get; set; }
 
         public byte[] Data { get; set; }
@@ -47,5 +56,49 @@ namespace DiscUtils.Nfs
         public bool Eof { get; set; }
 
         public Nfs3FileAttributes FileAttributes { get; set; }
+
+        public override void Write(XdrDataWriter writer)
+        {
+            writer.Write((int)Status);
+
+            writer.Write(FileAttributes != null);
+            if (FileAttributes != null)
+            {
+                FileAttributes.Write(writer);
+            }
+
+            if (Status == Nfs3Status.Ok)
+            {
+                writer.Write(Count);
+                writer.Write(Eof);
+                writer.WriteBuffer(Data);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3ReadResult);
+        }
+
+        public bool Equals(Nfs3ReadResult other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Status == Status
+                && object.Equals(other.FileAttributes, FileAttributes)
+                && other.Count == Count
+#if !NET20
+                && Enumerable.SequenceEqual(other.Data, Data)
+#endif
+                && other.Eof == Eof;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Status, FileAttributes, Count, Eof, Data);
+        }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3SetAttributes.cs
+++ b/Library/DiscUtils.Nfs/Nfs3SetAttributes.cs
@@ -20,10 +20,56 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     internal sealed class Nfs3SetAttributes
     {
+        public Nfs3SetAttributes()
+        {
+        }
+
+        public Nfs3SetAttributes(XdrDataReader reader)
+        {
+            SetMode = reader.ReadBool();
+
+            if (SetMode)
+            {
+                Mode = (UnixFilePermissions)reader.ReadInt32();
+            }
+
+            SetUid = reader.ReadBool();
+            if (SetUid)
+            {
+                Uid = reader.ReadUInt32();
+            }
+
+            SetGid = reader.ReadBool();
+            if (SetGid)
+            {
+                Gid = reader.ReadUInt32();
+            }
+
+            SetSize = reader.ReadBool();
+            if (SetSize)
+            {
+                Size = reader.ReadInt64();
+            }
+
+            SetAccessTime = (Nfs3SetTimeMethod)reader.ReadInt32();
+            if (SetAccessTime == Nfs3SetTimeMethod.ClientTime)
+            {
+                AccessTime = new Nfs3FileTime(reader);
+            }
+
+            SetModifyTime = (Nfs3SetTimeMethod)reader.ReadInt32();
+            if (SetModifyTime == Nfs3SetTimeMethod.ClientTime)
+            {
+                ModifyTime = new Nfs3FileTime(reader);
+            }
+        }
+
         public Nfs3FileTime AccessTime { get; set; }
 
         public uint Gid { get; set; }
@@ -84,6 +130,39 @@ namespace DiscUtils.Nfs
             {
                 ModifyTime.Write(writer);
             }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equal(obj as Nfs3SetAttributes);
+        }
+
+        public bool Equal(Nfs3SetAttributes other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.SetMode == SetMode
+                && other.Mode == Mode
+                && other.SetUid == SetUid
+                && other.Uid == Uid
+                && other.SetGid == SetGid
+                && other.Gid == Gid
+                && other.SetSize == SetSize
+                && other.Size == Size
+                && other.SetAccessTime == SetAccessTime
+                && object.Equals(other.AccessTime, AccessTime)
+                && other.SetModifyTime == SetModifyTime
+                && object.Equals(other.ModifyTime, ModifyTime);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                HashCode.Combine(SetMode, ModifyTime, SetUid, Uid, SetGid, Gid, SetSize, Size),
+                SetAccessTime, AccessTime, SetModifyTime, ModifyTime);
         }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3WeakCacheConsistency.cs
+++ b/Library/DiscUtils.Nfs/Nfs3WeakCacheConsistency.cs
@@ -20,6 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     internal sealed class Nfs3WeakCacheConsistency
@@ -37,8 +39,48 @@ namespace DiscUtils.Nfs
             }
         }
 
+        public Nfs3WeakCacheConsistency()
+        {
+        }
+
         public Nfs3FileAttributes After { get; set; }
 
         public Nfs3WeakCacheConsistencyAttr Before { get; set; }
+
+        public void Write(XdrDataWriter writer)
+        {
+            writer.Write(Before != null);
+            if (Before != null)
+            {
+                Before.Write(writer);
+            }
+
+            writer.Write(After != null);
+            if (After != null)
+            {
+                After.Write(writer);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3WeakCacheConsistency);
+        }
+
+        public bool Equals(Nfs3WeakCacheConsistency other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return object.Equals(other.After, After)
+                && object.Equals(other.Before, Before);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(After, Before);
+        }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3WeakCacheConsistencyAttr.cs
+++ b/Library/DiscUtils.Nfs/Nfs3WeakCacheConsistencyAttr.cs
@@ -20,6 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     internal sealed class Nfs3WeakCacheConsistencyAttr
@@ -31,10 +33,43 @@ namespace DiscUtils.Nfs
             ChangeTime = new Nfs3FileTime(reader);
         }
 
+        public Nfs3WeakCacheConsistencyAttr()
+        {
+        }
+
         public Nfs3FileTime ChangeTime { get; set; }
 
         public Nfs3FileTime ModifyTime { get; set; }
 
         public long Size { get; set; }
+
+        public void Write(XdrDataWriter writer)
+        {
+            writer.Write(Size);
+            ModifyTime.Write(writer);
+            ChangeTime.Write(writer);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3WeakCacheConsistencyAttr);
+        }
+
+        public bool Equals(Nfs3WeakCacheConsistencyAttr other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Size == Size
+                && object.Equals(other.ModifyTime, ModifyTime)
+                && object.Equals(other.ChangeTime, ChangeTime);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Size, ModifyTime, ChangeTime);
+        }
     }
 }

--- a/Library/DiscUtils.Nfs/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Nfs/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -9,6 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("DiscUtils.Nfs")]
 [assembly: AssemblyTrademark("")]
+[assembly: InternalsVisibleTo("LibraryTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010047ebec172a9831bb20fede77e17d784026ea7030d7055f2ae09576c71cebe77ebfab436d80580a4fcbba7242ff61bd52b686f5fe9d41fe7cd3e6c05b8a876eccf35b8ad7c5e3a6704295d7210b138d7280a6f72688419a65dd7a8612d66869f2e712c57c41fcc9196e4cb06d95d8e678f6967e65348c370405fb7eeb6aa1d3e8")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Nfs/RpcAcceptedReplyHeader.cs
+++ b/Library/DiscUtils.Nfs/RpcAcceptedReplyHeader.cs
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2008-2011, Kenneth Bell
+// Copyright (c) 2017, Quamotion
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,6 +21,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     internal class RpcAcceptedReplyHeader
@@ -27,6 +30,10 @@ namespace DiscUtils.Nfs
         public RpcAcceptStatus AcceptStatus;
         public RpcMismatchInfo MismatchInfo;
         public RpcAuthentication Verifier;
+
+        public RpcAcceptedReplyHeader()
+        {
+        }
 
         public RpcAcceptedReplyHeader(XdrDataReader reader)
         {
@@ -36,6 +43,38 @@ namespace DiscUtils.Nfs
             {
                 MismatchInfo = new RpcMismatchInfo(reader);
             }
+        }
+
+        public void Write(XdrDataWriter writer)
+        {
+            Verifier.Write(writer);
+            writer.Write((int)AcceptStatus);
+            if (AcceptStatus == RpcAcceptStatus.ProgramVersionMismatch)
+            {
+                MismatchInfo.Write(writer);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as RpcAcceptedReplyHeader);
+        }
+
+        public bool Equals(RpcAcceptedReplyHeader other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return object.Equals(other.Verifier, Verifier)
+                && other.AcceptStatus == AcceptStatus
+                && object.Equals(other.MismatchInfo, MismatchInfo);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Verifier, AcceptStatus, MismatchInfo);
         }
     }
 }

--- a/Library/DiscUtils.Nfs/RpcAuthentication.cs
+++ b/Library/DiscUtils.Nfs/RpcAuthentication.cs
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2008-2011, Kenneth Bell
+// Copyright (c) 2017, Quamotion
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,6 +21,7 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
 using System.IO;
 
 namespace DiscUtils.Nfs
@@ -28,6 +30,11 @@ namespace DiscUtils.Nfs
     {
         private readonly byte[] _body;
         private readonly RpcAuthFlavour _flavour;
+
+        public RpcAuthentication()
+        {
+            _body = new byte[400];
+        }
 
         public RpcAuthentication(XdrDataReader reader)
         {
@@ -54,6 +61,26 @@ namespace DiscUtils.Nfs
         {
             writer.Write((int)_flavour);
             writer.WriteBuffer(_body);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as RpcAuthentication);
+        }
+
+        public bool Equals(RpcAuthentication other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+            
+            return other._flavour == _flavour;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(_flavour);
         }
     }
 }

--- a/Library/DiscUtils.Nfs/RpcRejectedReplyHeader.cs
+++ b/Library/DiscUtils.Nfs/RpcRejectedReplyHeader.cs
@@ -20,6 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     internal class RpcRejectedReplyHeader
@@ -27,6 +29,10 @@ namespace DiscUtils.Nfs
         public RpcAuthenticationStatus AuthenticationStatus;
         public RpcMismatchInfo MismatchInfo;
         public RpcRejectedStatus Status;
+
+        public RpcRejectedReplyHeader()
+        {
+        }
 
         public RpcRejectedReplyHeader(XdrDataReader reader)
         {
@@ -39,6 +45,41 @@ namespace DiscUtils.Nfs
             {
                 AuthenticationStatus = (RpcAuthenticationStatus)reader.ReadInt32();
             }
+        }
+
+        public void Write(XdrDataWriter writer)
+        {
+            writer.Write((int)Status);
+            if (Status == RpcRejectedStatus.RpcMismatch)
+            {
+                MismatchInfo.Write(writer);
+            }
+            else
+            {
+                writer.Write((int)AuthenticationStatus);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as RpcRejectedReplyHeader);
+        }
+
+        public bool Equals(RpcRejectedReplyHeader other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Status == Status
+                && object.Equals(other.MismatchInfo, MismatchInfo)
+                && other.AuthenticationStatus == AuthenticationStatus;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Status, MismatchInfo, AuthenticationStatus);
         }
     }
 }

--- a/Library/DiscUtils.Nfs/RpcReplyHeader.cs
+++ b/Library/DiscUtils.Nfs/RpcReplyHeader.cs
@@ -20,6 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     internal class RpcReplyHeader
@@ -27,6 +29,10 @@ namespace DiscUtils.Nfs
         public RpcAcceptedReplyHeader AcceptReply;
         public RpcRejectedReplyHeader RejectedReply;
         public RpcReplyStatus Status;
+
+        public RpcReplyHeader()
+        {
+        }
 
         public RpcReplyHeader(XdrDataReader reader)
         {
@@ -39,6 +45,42 @@ namespace DiscUtils.Nfs
             {
                 RejectedReply = new RpcRejectedReplyHeader(reader);
             }
+        }
+
+        public void Write(XdrDataWriter writer)
+        {
+            writer.Write((int)Status);
+
+            if (Status == RpcReplyStatus.Accepted)
+            {
+                AcceptReply.Write(writer);
+            }
+            else
+            {
+                RejectedReply.Write(writer);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as RpcReplyHeader);
+        }
+
+        public bool Equals(RpcReplyHeader other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Status == Status
+                && object.Equals(other.AcceptReply, AcceptReply)
+                && object.Equals(other.RejectedReply, RejectedReply);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Status, AcceptReply, RejectedReply);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/Nfs3DirectoryEntryTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3DirectoryEntryTest.cs
@@ -1,0 +1,73 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using DiscUtils;
+using DiscUtils.Nfs;
+using System;
+using System.IO;
+using Xunit;
+
+namespace LibraryTests.Nfs
+{
+    public class Nfs3DirectoryEntryTest
+    {
+        [Fact]
+        public void RoundTripTest()
+        {
+            Nfs3DirectoryEntry entry = new Nfs3DirectoryEntry()
+            {
+                Cookie = 1,
+                FileAttributes = new Nfs3FileAttributes()
+                {
+                    AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
+                    BytesUsed = 2,
+                    ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
+                    FileId = 3,
+                    FileSystemId = 4,
+                    Gid = 5,
+                    LinkCount = 6,
+                    Mode = UnixFilePermissions.GroupAll,
+                    ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 3)),
+                    RdevMajor = 7,
+                    RdevMinor = 8,
+                    Size = 9,
+                    Type = Nfs3FileType.NamedPipe,
+                    Uid = 10
+                }
+            };
+
+            Nfs3DirectoryEntry clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                entry.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new Nfs3DirectoryEntry(reader);
+            }
+
+            Assert.Equal(entry, clone);
+        }
+    }
+}

--- a/Tests/LibraryTests/Nfs/Nfs3FileAttributesTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3FileAttributesTest.cs
@@ -1,0 +1,69 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using DiscUtils;
+using DiscUtils.Nfs;
+using System;
+using System.IO;
+using Xunit;
+
+namespace LibraryTests.Nfs
+{
+    public class Nfs3FileAttributesTest
+    {
+        [Fact]
+        public void RoundTripTest()
+        {
+            Nfs3FileAttributes attributes = new Nfs3FileAttributes()
+            {
+                AccessTime = new Nfs3FileTime(new DateTime(2018, 1, 1)),
+                BytesUsed = 1,
+                ChangeTime = new Nfs3FileTime(new DateTime(2018, 1, 2)),
+                FileId = 3,
+                FileSystemId = 4,
+                Gid = 5,
+                LinkCount = 6,
+                Mode = UnixFilePermissions.GroupExecute,
+                ModifyTime = new Nfs3FileTime(new DateTime(2018, 1, 3)),
+                RdevMajor = 7,
+                RdevMinor = 8,
+                Size = 9,
+                Type = Nfs3FileType.NamedPipe,
+                Uid = 11
+            };
+
+            Nfs3FileAttributes clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                attributes.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new Nfs3FileAttributes(reader);
+            }
+
+            Assert.Equal(attributes, clone);
+        }
+    }
+}

--- a/Tests/LibraryTests/Nfs/Nfs3FileHandleTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3FileHandleTest.cs
@@ -1,5 +1,5 @@
-//
-// Copyright (c) 2008-2011, Kenneth Bell
+﻿//
+// Copyright (c) 2017, Quamotion
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,20 +20,35 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using System;
+using DiscUtils.Nfs;
+using System.IO;
+using Xunit;
 
-namespace DiscUtils.Nfs
+namespace LibraryTests.Nfs
 {
-    /// <summary>
-    /// Base class for all NFS result structures.
-    /// </summary>
-    internal abstract class Nfs3CallResult
+    public class Nfs3FileHandleTest
     {
-        public Nfs3Status Status { get; set; }
-
-        public virtual void Write(XdrDataWriter writer)
+        [Fact]
+        public void RoundTripTest()
         {
-            throw new NotSupportedException();
+            Nfs3FileHandle attributes = new Nfs3FileHandle()
+            {
+                Value = new byte[] { 0x01 }
+            };
+
+            Nfs3FileHandle clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                attributes.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new Nfs3FileHandle(reader);
+            }
+
+            Assert.Equal(attributes, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/Nfs3FileSystemInfoResultTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3FileSystemInfoResultTest.cs
@@ -28,47 +28,59 @@ using Xunit;
 
 namespace LibraryTests.Nfs
 {
-    public class Nfs3DirectoryEntryTest
+    public class Nfs3FileSystemInfoResultTest
     {
         [Fact]
         public void RoundTripTest()
         {
-            Nfs3DirectoryEntry entry = new Nfs3DirectoryEntry()
+            Nfs3FileSystemInfoResult result = new Nfs3FileSystemInfoResult()
             {
-                Cookie = 1,
-                FileAttributes = new Nfs3FileAttributes()
+                FileSystemInfo = new Nfs3FileSystemInfo()
+                {
+                    DirectoryPreferredBytes = 1,
+                    FileSystemProperties = Nfs3FileSystemProperties.HardLinks,
+                    MaxFileSize = 3,
+                    ReadMaxBytes = 4,
+                    ReadMultipleSize = 5,
+                    ReadPreferredBytes = 6,
+                    TimePrecision = Nfs3FileTime.Precision,
+                    WriteMaxBytes = 8,
+                    WriteMultipleSize = 9,
+                    WritePreferredBytes = 10
+                },
+                PostOpAttributes = new Nfs3FileAttributes()
                 {
                     AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
                     BytesUsed = 2,
-                    ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
-                    FileId = 3,
-                    FileSystemId = 4,
-                    Gid = 5,
-                    LinkCount = 6,
-                    Mode = UnixFilePermissions.GroupAll,
-                    ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 3)),
-                    RdevMajor = 7,
-                    RdevMinor = 8,
-                    Size = 9,
-                    Type = Nfs3FileType.NamedPipe,
-                    Uid = 10
+                    ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 3)),
+                    FileId = 4,
+                    FileSystemId = 5,
+                    Gid = 6,
+                    LinkCount = 7,
+                    Mode = UnixFilePermissions.OthersExecute,
+                    ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 8)),
+                    RdevMajor = 9,
+                    RdevMinor = 10,
+                    Size = 11,
+                    Type = Nfs3FileType.BlockDevice,
+                    Uid = 12
                 },
-                Name = "test"
+                Status = Nfs3Status.Ok
             };
 
-            Nfs3DirectoryEntry clone = null;
+            Nfs3FileSystemInfoResult clone = null;
 
             using (MemoryStream stream = new MemoryStream())
             {
                 XdrDataWriter writer = new XdrDataWriter(stream);
-                entry.Write(writer);
+                result.Write(writer);
 
                 stream.Position = 0;
                 XdrDataReader reader = new XdrDataReader(stream);
-                clone = new Nfs3DirectoryEntry(reader);
+                clone = new Nfs3FileSystemInfoResult(reader);
             }
 
-            Assert.Equal(entry, clone);
+            Assert.Equal(result, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/Nfs3FileSystemInfoTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3FileSystemInfoTest.cs
@@ -1,5 +1,4 @@
-//
-// Copyright (c) 2008-2011, Kenneth Bell
+﻿//
 // Copyright (c) 2017, Quamotion
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -21,50 +20,44 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using System;
+using DiscUtils.Nfs;
+using System.IO;
+using Xunit;
 
-namespace DiscUtils.Nfs
+namespace LibraryTests.Nfs
 {
-    internal class RpcMismatchInfo
+    public class Nfs3FileSystemInfoTest
     {
-        public uint High;
-        public uint Low;
-
-        public RpcMismatchInfo()
+        [Fact]
+        public void RoundTripTest()
         {
-        }
-
-        public RpcMismatchInfo(XdrDataReader reader)
-        {
-            Low = reader.ReadUInt32();
-            High = reader.ReadUInt32();
-        }
-
-        public void Write(XdrDataWriter writer)
-        {
-            writer.Write(Low);
-            writer.Write(High);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as RpcMismatchInfo);
-        }
-
-        public bool Equals(RpcMismatchInfo other)
-        {
-            if (other == null)
+            Nfs3FileSystemInfo attributes = new Nfs3FileSystemInfo()
             {
-                return false;
+                DirectoryPreferredBytes = 1,
+                FileSystemProperties = Nfs3FileSystemProperties.HardLinks,
+                MaxFileSize = 2,
+                ReadMaxBytes = 3,
+                ReadMultipleSize = 4,
+                ReadPreferredBytes = 5,
+                TimePrecision = 6,
+                WriteMaxBytes = 7,
+                WriteMultipleSize = 8,
+                WritePreferredBytes = 9
+            };
+
+            Nfs3FileSystemInfo clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                attributes.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new Nfs3FileSystemInfo(reader);
             }
 
-            return other.High == High
-                && other.Low == Low;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(High, Low);
+            Assert.Equal(attributes, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/Nfs3FileTimeTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3FileTimeTest.cs
@@ -26,38 +26,26 @@ using Xunit;
 
 namespace LibraryTests.Nfs
 {
-    public class Nfs3FileSystemInfoTest
+    public class Nfs3FileTimeTest
     {
         [Fact]
         public void RoundTripTest()
         {
-            Nfs3FileSystemInfo attributes = new Nfs3FileSystemInfo()
-            {
-                DirectoryPreferredBytes = 1,
-                FileSystemProperties = Nfs3FileSystemProperties.HardLinks,
-                MaxFileSize = 2,
-                ReadMaxBytes = 3,
-                ReadMultipleSize = 4,
-                ReadPreferredBytes = 5,
-                TimePrecision = Nfs3FileTime.Precision,
-                WriteMaxBytes = 7,
-                WriteMultipleSize = 8,
-                WritePreferredBytes = 9
-            };
+            Nfs3FileTime time = new Nfs3FileTime(1, 2);
 
-            Nfs3FileSystemInfo clone = null;
+            Nfs3FileTime clone = null;
 
             using (MemoryStream stream = new MemoryStream())
             {
                 XdrDataWriter writer = new XdrDataWriter(stream);
-                attributes.Write(writer);
+                time.Write(writer);
 
                 stream.Position = 0;
                 XdrDataReader reader = new XdrDataReader(stream);
-                clone = new Nfs3FileSystemInfo(reader);
+                clone = new Nfs3FileTime(reader);
             }
 
-            Assert.Equal(attributes, clone);
+            Assert.Equal(time, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/Nfs3LookupResultTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3LookupResultTest.cs
@@ -28,47 +28,67 @@ using Xunit;
 
 namespace LibraryTests.Nfs
 {
-    public class Nfs3DirectoryEntryTest
+    public class Nfs3LookupResultTest
     {
         [Fact]
         public void RoundTripTest()
         {
-            Nfs3DirectoryEntry entry = new Nfs3DirectoryEntry()
+            Nfs3LookupResult result = new Nfs3LookupResult()
             {
-                Cookie = 1,
-                FileAttributes = new Nfs3FileAttributes()
+                DirAttributes = new Nfs3FileAttributes()
                 {
                     AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
-                    BytesUsed = 2,
+                    BytesUsed = 1,
                     ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
-                    FileId = 3,
-                    FileSystemId = 4,
-                    Gid = 5,
-                    LinkCount = 6,
+                    FileId = 2,
+                    FileSystemId = 3,
+                    Gid = 4,
+                    LinkCount = 5,
                     Mode = UnixFilePermissions.GroupAll,
                     ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 3)),
-                    RdevMajor = 7,
-                    RdevMinor = 8,
-                    Size = 9,
-                    Type = Nfs3FileType.NamedPipe,
-                    Uid = 10
+                    RdevMajor = 6,
+                    RdevMinor = 7,
+                    Size = 8,
+                    Type = Nfs3FileType.BlockDevice,
+                    Uid = 9
                 },
-                Name = "test"
+                ObjectAttributes = new Nfs3FileAttributes()
+                {
+                    AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 10)),
+                    BytesUsed = 11,
+                    ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 12)),
+                    FileId = 12,
+                    FileSystemId = 13,
+                    Gid = 14,
+                    LinkCount = 15,
+                    Mode = UnixFilePermissions.GroupWrite,
+                    ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 13)),
+                    RdevMajor = 16,
+                    RdevMinor = 17,
+                    Size = 18,
+                    Type = Nfs3FileType.Socket,
+                    Uid = 19
+                },
+                ObjectHandle = new Nfs3FileHandle()
+                {
+                    Value = new byte[] { 0x20 }
+                },
+                Status = Nfs3Status.Ok
             };
 
-            Nfs3DirectoryEntry clone = null;
+            Nfs3LookupResult clone = null;
 
             using (MemoryStream stream = new MemoryStream())
             {
                 XdrDataWriter writer = new XdrDataWriter(stream);
-                entry.Write(writer);
+                result.Write(writer);
 
                 stream.Position = 0;
                 XdrDataReader reader = new XdrDataReader(stream);
-                clone = new Nfs3DirectoryEntry(reader);
+                clone = new Nfs3LookupResult(reader);
             }
 
-            Assert.Equal(entry, clone);
+            Assert.Equal(result, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/Nfs3MountResultTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3MountResultTest.cs
@@ -21,43 +21,44 @@
 //
 
 using DiscUtils.Nfs;
+using System.Collections.Generic;
 using System.IO;
 using Xunit;
 
 namespace LibraryTests.Nfs
 {
-    public class Nfs3FileSystemInfoTest
+    public class Nfs3MountResultTest
     {
         [Fact]
         public void RoundTripTest()
         {
-            Nfs3FileSystemInfo attributes = new Nfs3FileSystemInfo()
+            Nfs3MountResult result = new Nfs3MountResult()
             {
-                DirectoryPreferredBytes = 1,
-                FileSystemProperties = Nfs3FileSystemProperties.HardLinks,
-                MaxFileSize = 2,
-                ReadMaxBytes = 3,
-                ReadMultipleSize = 4,
-                ReadPreferredBytes = 5,
-                TimePrecision = Nfs3FileTime.Precision,
-                WriteMaxBytes = 7,
-                WriteMultipleSize = 8,
-                WritePreferredBytes = 9
+                AuthFlavours = new List<RpcAuthFlavour>()
+                 {
+                      RpcAuthFlavour.Des,
+                       RpcAuthFlavour.Null
+                 },
+                FileHandle = new Nfs3FileHandle()
+                {
+                    Value = new byte[] { 0x5 }
+                },
+                Status = Nfs3Status.Ok
             };
 
-            Nfs3FileSystemInfo clone = null;
+            Nfs3MountResult clone = null;
 
             using (MemoryStream stream = new MemoryStream())
             {
                 XdrDataWriter writer = new XdrDataWriter(stream);
-                attributes.Write(writer);
+                result.Write(writer);
 
                 stream.Position = 0;
                 XdrDataReader reader = new XdrDataReader(stream);
-                clone = new Nfs3FileSystemInfo(reader);
+                clone = new Nfs3MountResult(reader);
             }
 
-            Assert.Equal(attributes, clone);
+            Assert.Equal(result, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/Nfs3ReadDirPlusResultTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3ReadDirPlusResultTest.cs
@@ -1,0 +1,106 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using DiscUtils;
+using DiscUtils.Nfs;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace LibraryTests.Nfs
+{
+    public class Nfs3ReadDirPlusResultTest
+    {
+        [Fact]
+        public void RoundTripTest()
+        {
+            Nfs3ReadDirPlusResult result = new Nfs3ReadDirPlusResult()
+            {
+                CookieVerifier = 1,
+                DirAttributes = new Nfs3FileAttributes()
+                {
+                    AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
+                    BytesUsed = 1,
+                    ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
+                    FileId = 2,
+                    FileSystemId = 3,
+                    Gid = 4,
+                    LinkCount = 5,
+                    Mode = UnixFilePermissions.GroupAll,
+                    ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 3)),
+                    RdevMajor = 6,
+                    RdevMinor = 7,
+                    Size = 8,
+                    Type = Nfs3FileType.BlockDevice,
+                    Uid = 9
+                },
+                DirEntries = new List<Nfs3DirectoryEntry>()
+                {
+                    new Nfs3DirectoryEntry()
+                    {
+                         Cookie = 2,
+                         FileAttributes = new Nfs3FileAttributes()
+                         {
+                            AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 10)),
+                            BytesUsed = 11,
+                            ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 12)),
+                            FileId = 12,
+                            FileSystemId = 13,
+                            Gid = 14,
+                            LinkCount = 15,
+                            Mode = UnixFilePermissions.GroupWrite,
+                            ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 13)),
+                            RdevMajor = 16,
+                            RdevMinor = 17,
+                            Size = 18,
+                            Type = Nfs3FileType.Socket,
+                            Uid = 19
+                         },
+                         FileHandle = new Nfs3FileHandle()
+                         {
+                              Value = new byte[]{0xa}
+                         },
+                         FileId = 99,
+                         Name = "test"
+                    }
+                },
+                Eof = false,
+                Status = Nfs3Status.Ok
+            };
+
+            Nfs3ReadDirPlusResult clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                result.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new Nfs3ReadDirPlusResult(reader);
+            }
+
+            Assert.Equal(result, clone);
+        }
+    }
+}

--- a/Tests/LibraryTests/Nfs/Nfs3ReadResultTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3ReadResultTest.cs
@@ -20,44 +20,57 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using DiscUtils;
 using DiscUtils.Nfs;
+using System;
 using System.IO;
 using Xunit;
 
 namespace LibraryTests.Nfs
 {
-    public class Nfs3FileSystemInfoTest
+    public class Nfs3ReadResultTest
     {
         [Fact]
         public void RoundTripTest()
         {
-            Nfs3FileSystemInfo attributes = new Nfs3FileSystemInfo()
+            Nfs3ReadResult result = new Nfs3ReadResult()
             {
-                DirectoryPreferredBytes = 1,
-                FileSystemProperties = Nfs3FileSystemProperties.HardLinks,
-                MaxFileSize = 2,
-                ReadMaxBytes = 3,
-                ReadMultipleSize = 4,
-                ReadPreferredBytes = 5,
-                TimePrecision = Nfs3FileTime.Precision,
-                WriteMaxBytes = 7,
-                WriteMultipleSize = 8,
-                WritePreferredBytes = 9
+                Count = 1,
+                Data = new byte[] { 0x02, 0x03 },
+                Eof = false,
+                FileAttributes = new Nfs3FileAttributes()
+                {
+                    AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
+                    BytesUsed = 1,
+                    ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
+                    FileId = 2,
+                    FileSystemId = 3,
+                    Gid = 4,
+                    LinkCount = 5,
+                    Mode = UnixFilePermissions.GroupAll,
+                    ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 3)),
+                    RdevMajor = 6,
+                    RdevMinor = 7,
+                    Size = 8,
+                    Type = Nfs3FileType.BlockDevice,
+                    Uid = 9
+                },
+                Status = Nfs3Status.Ok
             };
 
-            Nfs3FileSystemInfo clone = null;
+            Nfs3ReadResult clone = null;
 
             using (MemoryStream stream = new MemoryStream())
             {
                 XdrDataWriter writer = new XdrDataWriter(stream);
-                attributes.Write(writer);
+                result.Write(writer);
 
                 stream.Position = 0;
                 XdrDataReader reader = new XdrDataReader(stream);
-                clone = new Nfs3FileSystemInfo(reader);
+                clone = new Nfs3ReadResult(reader);
             }
 
-            Assert.Equal(attributes, clone);
+            Assert.Equal(result, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/Nfs3SetAttributesTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3SetAttributesTest.cs
@@ -1,5 +1,5 @@
 ﻿//
-// Copyright (c) 2017, Quamotion
+// Copyright (c) 2008-2011, Kenneth Bell
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,32 +20,36 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using DiscUtils;
 using DiscUtils.Nfs;
+using System;
 using System.IO;
 using Xunit;
 
 namespace LibraryTests.Nfs
 {
-    public class Nfs3FileSystemInfoTest
+    public class Nfs3SetAttributesTest
     {
         [Fact]
         public void RoundTripTest()
         {
-            Nfs3FileSystemInfo attributes = new Nfs3FileSystemInfo()
+            Nfs3SetAttributes attributes = new Nfs3SetAttributes()
             {
-                DirectoryPreferredBytes = 1,
-                FileSystemProperties = Nfs3FileSystemProperties.HardLinks,
-                MaxFileSize = 2,
-                ReadMaxBytes = 3,
-                ReadMultipleSize = 4,
-                ReadPreferredBytes = 5,
-                TimePrecision = Nfs3FileTime.Precision,
-                WriteMaxBytes = 7,
-                WriteMultipleSize = 8,
-                WritePreferredBytes = 9
+                AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
+                Gid = 1,
+                Mode = UnixFilePermissions.GroupAll,
+                ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
+                SetAccessTime = Nfs3SetTimeMethod.ClientTime,
+                SetGid = true,
+                SetMode = true,
+                SetModifyTime = Nfs3SetTimeMethod.ClientTime,
+                SetSize = true,
+                SetUid = true,
+                Size = 4,
+                Uid = 5
             };
 
-            Nfs3FileSystemInfo clone = null;
+            Nfs3SetAttributes clone = null;
 
             using (MemoryStream stream = new MemoryStream())
             {
@@ -54,7 +58,7 @@ namespace LibraryTests.Nfs
 
                 stream.Position = 0;
                 XdrDataReader reader = new XdrDataReader(stream);
-                clone = new Nfs3FileSystemInfo(reader);
+                clone = new Nfs3SetAttributes(reader);
             }
 
             Assert.Equal(attributes, clone);

--- a/Tests/LibraryTests/Nfs/Nfs3WeakCacheConsistencyAttrTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3WeakCacheConsistencyAttrTest.cs
@@ -21,43 +21,37 @@
 //
 
 using DiscUtils.Nfs;
+using System;
 using System.IO;
 using Xunit;
 
 namespace LibraryTests.Nfs
 {
-    public class Nfs3FileSystemInfoTest
+    public class Nfs3WeakCacheConsistencyAttrTest
     {
         [Fact]
         public void RoundTripTest()
         {
-            Nfs3FileSystemInfo attributes = new Nfs3FileSystemInfo()
+            Nfs3WeakCacheConsistencyAttr attr = new Nfs3WeakCacheConsistencyAttr()
             {
-                DirectoryPreferredBytes = 1,
-                FileSystemProperties = Nfs3FileSystemProperties.HardLinks,
-                MaxFileSize = 2,
-                ReadMaxBytes = 3,
-                ReadMultipleSize = 4,
-                ReadPreferredBytes = 5,
-                TimePrecision = Nfs3FileTime.Precision,
-                WriteMaxBytes = 7,
-                WriteMultipleSize = 8,
-                WritePreferredBytes = 9
+                ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
+                ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
+                Size = 3
             };
 
-            Nfs3FileSystemInfo clone = null;
+            Nfs3WeakCacheConsistencyAttr clone = null;
 
             using (MemoryStream stream = new MemoryStream())
             {
                 XdrDataWriter writer = new XdrDataWriter(stream);
-                attributes.Write(writer);
+                attr.Write(writer);
 
                 stream.Position = 0;
                 XdrDataReader reader = new XdrDataReader(stream);
-                clone = new Nfs3FileSystemInfo(reader);
+                clone = new Nfs3WeakCacheConsistencyAttr(reader);
             }
 
-            Assert.Equal(attributes, clone);
+            Assert.Equal(attr, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/Nfs3WeakCacheConsistencyTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3WeakCacheConsistencyTest.cs
@@ -20,44 +20,59 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using DiscUtils;
 using DiscUtils.Nfs;
+using System;
 using System.IO;
 using Xunit;
 
 namespace LibraryTests.Nfs
 {
-    public class Nfs3FileSystemInfoTest
+    public class Nfs3WeakCacheConsistencyTest
     {
         [Fact]
         public void RoundTripTest()
         {
-            Nfs3FileSystemInfo attributes = new Nfs3FileSystemInfo()
+            Nfs3WeakCacheConsistency consistency = new Nfs3WeakCacheConsistency()
             {
-                DirectoryPreferredBytes = 1,
-                FileSystemProperties = Nfs3FileSystemProperties.HardLinks,
-                MaxFileSize = 2,
-                ReadMaxBytes = 3,
-                ReadMultipleSize = 4,
-                ReadPreferredBytes = 5,
-                TimePrecision = Nfs3FileTime.Precision,
-                WriteMaxBytes = 7,
-                WriteMultipleSize = 8,
-                WritePreferredBytes = 9
+                Before = new Nfs3WeakCacheConsistencyAttr()
+                {
+                    ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
+                    ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
+                    Size = 3
+                },
+                After = new Nfs3FileAttributes()
+                {
+                    AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
+                    BytesUsed = 2,
+                    ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
+                    FileId = 3,
+                    FileSystemId = 4,
+                    Gid = 5,
+                    LinkCount = 6,
+                    Mode = UnixFilePermissions.GroupAll,
+                    ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 3)),
+                    RdevMajor = 7,
+                    RdevMinor = 8,
+                    Size = 9,
+                    Type = Nfs3FileType.NamedPipe,
+                    Uid = 10
+                }
             };
 
-            Nfs3FileSystemInfo clone = null;
+            Nfs3WeakCacheConsistency clone = null;
 
             using (MemoryStream stream = new MemoryStream())
             {
                 XdrDataWriter writer = new XdrDataWriter(stream);
-                attributes.Write(writer);
+                consistency.Write(writer);
 
                 stream.Position = 0;
                 XdrDataReader reader = new XdrDataReader(stream);
-                clone = new Nfs3FileSystemInfo(reader);
+                clone = new Nfs3WeakCacheConsistency(reader);
             }
 
-            Assert.Equal(attributes, clone);
+            Assert.Equal(consistency, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/Nfs3WriteResultTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3WriteResultTest.cs
@@ -28,47 +28,58 @@ using Xunit;
 
 namespace LibraryTests.Nfs
 {
-    public class Nfs3DirectoryEntryTest
+    public class Nfs3WriteResultTest
     {
         [Fact]
         public void RoundTripTest()
         {
-            Nfs3DirectoryEntry entry = new Nfs3DirectoryEntry()
+            Nfs3WriteResult result = new Nfs3WriteResult()
             {
-                Cookie = 1,
-                FileAttributes = new Nfs3FileAttributes()
+                CacheConsistency = new Nfs3WeakCacheConsistency()
                 {
-                    AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
-                    BytesUsed = 2,
-                    ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
-                    FileId = 3,
-                    FileSystemId = 4,
-                    Gid = 5,
-                    LinkCount = 6,
-                    Mode = UnixFilePermissions.GroupAll,
-                    ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 3)),
-                    RdevMajor = 7,
-                    RdevMinor = 8,
-                    Size = 9,
-                    Type = Nfs3FileType.NamedPipe,
-                    Uid = 10
+                    Before = new Nfs3WeakCacheConsistencyAttr()
+                    {
+                        ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
+                        ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
+                        Size = 3
+                    },
+                    After = new Nfs3FileAttributes()
+                    {
+                        AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
+                        BytesUsed = 2,
+                        ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
+                        FileId = 3,
+                        FileSystemId = 4,
+                        Gid = 5,
+                        LinkCount = 6,
+                        Mode = UnixFilePermissions.GroupAll,
+                        ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 3)),
+                        RdevMajor = 7,
+                        RdevMinor = 8,
+                        Size = 9,
+                        Type = Nfs3FileType.NamedPipe,
+                        Uid = 10
+                    }
                 },
-                Name = "test"
+                Count = 1,
+                HowCommitted = 2,
+                Status = Nfs3Status.Ok,
+                WriteVerifier = 3
             };
 
-            Nfs3DirectoryEntry clone = null;
+            Nfs3WriteResult clone = null;
 
             using (MemoryStream stream = new MemoryStream())
             {
                 XdrDataWriter writer = new XdrDataWriter(stream);
-                entry.Write(writer);
+                result.Write(writer);
 
                 stream.Position = 0;
                 XdrDataReader reader = new XdrDataReader(stream);
-                clone = new Nfs3DirectoryEntry(reader);
+                clone = new Nfs3WriteResult(reader);
             }
 
-            Assert.Equal(entry, clone);
+            Assert.Equal(result, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/RpcAcceptedReplyHeaderTest.cs
+++ b/Tests/LibraryTests/Nfs/RpcAcceptedReplyHeaderTest.cs
@@ -1,5 +1,5 @@
-//
-// Copyright (c) 2008-2011, Kenneth Bell
+﻿//
+// Copyright (c) 2017, Quamotion
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,20 +20,43 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using System;
+using DiscUtils.Nfs;
+using System.IO;
+using Xunit;
 
-namespace DiscUtils.Nfs
+namespace LibraryTests.Nfs
 {
-    /// <summary>
-    /// Base class for all NFS result structures.
-    /// </summary>
-    internal abstract class Nfs3CallResult
+    public class RpcAcceptedReplyHeaderTest
     {
-        public Nfs3Status Status { get; set; }
-
-        public virtual void Write(XdrDataWriter writer)
+        [Fact]
+        public void RoundTripTest()
         {
-            throw new NotSupportedException();
+            RpcAcceptedReplyHeader header = new RpcAcceptedReplyHeader()
+            {
+                AcceptStatus = RpcAcceptStatus.ProgramVersionMismatch,
+                MismatchInfo = new RpcMismatchInfo()
+                {
+                    High = 1,
+                    Low = 2
+                },
+                Verifier = new RpcAuthentication()
+                {
+                }
+            };
+
+            RpcAcceptedReplyHeader clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                header.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new RpcAcceptedReplyHeader(reader);
+            }
+
+            Assert.Equal(header, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/RpcAuthenticationTests.cs
+++ b/Tests/LibraryTests/Nfs/RpcAuthenticationTests.cs
@@ -21,10 +21,7 @@
 //
 
 using DiscUtils.Nfs;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using Xunit;
 
 namespace LibraryTests.Nfs

--- a/Tests/LibraryTests/Nfs/RpcAuthenticationTests.cs
+++ b/Tests/LibraryTests/Nfs/RpcAuthenticationTests.cs
@@ -1,5 +1,5 @@
-//
-// Copyright (c) 2008-2011, Kenneth Bell
+﻿//
+// Copyright (c) 2017, Quamotion
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,20 +20,35 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using DiscUtils.Nfs;
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
 
-namespace DiscUtils.Nfs
+namespace LibraryTests.Nfs
 {
-    /// <summary>
-    /// Base class for all NFS result structures.
-    /// </summary>
-    internal abstract class Nfs3CallResult
+    public class RpcAuthenticationTests
     {
-        public Nfs3Status Status { get; set; }
-
-        public virtual void Write(XdrDataWriter writer)
+        [Fact]
+        public void RoundTripTest()
         {
-            throw new NotSupportedException();
+            RpcAuthentication authentication = new RpcAuthentication();
+
+            RpcAuthentication clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                authentication.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new RpcAuthentication(reader);
+            }
+
+            Assert.Equal(authentication, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/RpcCallHeaderTest.cs
+++ b/Tests/LibraryTests/Nfs/RpcCallHeaderTest.cs
@@ -1,5 +1,5 @@
-//
-// Copyright (c) 2008-2011, Kenneth Bell
+﻿//
+// Copyright (c) 2017, Quamotion
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,20 +20,44 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using System;
+using DiscUtils.Nfs;
+using System.IO;
+using Xunit;
 
-namespace DiscUtils.Nfs
+namespace LibraryTests.Nfs
 {
-    /// <summary>
-    /// Base class for all NFS result structures.
-    /// </summary>
-    internal abstract class Nfs3CallResult
+    public class RpcCallHeaderTest
     {
-        public Nfs3Status Status { get; set; }
-
-        public virtual void Write(XdrDataWriter writer)
+        [Fact]
+        public void RoundTripTest()
         {
-            throw new NotSupportedException();
+            RpcCallHeader header = new RpcCallHeader()
+            {
+                Credentials = new RpcAuthentication()
+                {
+                },
+                Proc = NfsProc3.Commit,
+                Program = 5,
+                RpcVersion = 6,
+                Verifier = new RpcAuthentication()
+                {
+                },
+                Version = 7
+            };
+
+            RpcCallHeader clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                header.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new RpcCallHeader(reader);
+            }
+
+            Assert.Equal(header, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/RpcMessageHeaderTest.cs
+++ b/Tests/LibraryTests/Nfs/RpcMessageHeaderTest.cs
@@ -26,38 +26,26 @@ using Xunit;
 
 namespace LibraryTests.Nfs
 {
-    public class Nfs3FileSystemInfoTest
+    public class RpcMessageHeaderTest
     {
         [Fact]
         public void RoundTripTest()
         {
-            Nfs3FileSystemInfo attributes = new Nfs3FileSystemInfo()
-            {
-                DirectoryPreferredBytes = 1,
-                FileSystemProperties = Nfs3FileSystemProperties.HardLinks,
-                MaxFileSize = 2,
-                ReadMaxBytes = 3,
-                ReadMultipleSize = 4,
-                ReadPreferredBytes = 5,
-                TimePrecision = Nfs3FileTime.Precision,
-                WriteMaxBytes = 7,
-                WriteMultipleSize = 8,
-                WritePreferredBytes = 9
-            };
+            RpcMessageHeader header = RpcMessageHeader.Accepted(1);
 
-            Nfs3FileSystemInfo clone = null;
+            RpcMessageHeader clone = null;
 
             using (MemoryStream stream = new MemoryStream())
             {
                 XdrDataWriter writer = new XdrDataWriter(stream);
-                attributes.Write(writer);
+                header.Write(writer);
 
                 stream.Position = 0;
                 XdrDataReader reader = new XdrDataReader(stream);
-                clone = new Nfs3FileSystemInfo(reader);
+                clone = new RpcMessageHeader(reader);
             }
 
-            Assert.Equal(attributes, clone);
+            Assert.Equal(header, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/RpcMismatchInfoTest.cs
+++ b/Tests/LibraryTests/Nfs/RpcMismatchInfoTest.cs
@@ -1,5 +1,5 @@
-//
-// Copyright (c) 2008-2011, Kenneth Bell
+﻿//
+// Copyright (c) 2017, Quamotion
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,20 +20,36 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using System;
+using DiscUtils.Nfs;
+using System.IO;
+using Xunit;
 
-namespace DiscUtils.Nfs
+namespace LibraryTests.Nfs
 {
-    /// <summary>
-    /// Base class for all NFS result structures.
-    /// </summary>
-    internal abstract class Nfs3CallResult
+    public class RpcMismatchInfoTest
     {
-        public Nfs3Status Status { get; set; }
-
-        public virtual void Write(XdrDataWriter writer)
+        [Fact]
+        public void RoundTripTest()
         {
-            throw new NotSupportedException();
+            RpcMismatchInfo info = new RpcMismatchInfo()
+            {
+                 High = 1,
+                 Low = 2
+            };
+
+            RpcMismatchInfo clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                info.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new RpcMismatchInfo(reader);
+            }
+
+            Assert.Equal(info, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/RpcRejectedReplyHeaderTest.cs
+++ b/Tests/LibraryTests/Nfs/RpcRejectedReplyHeaderTest.cs
@@ -26,38 +26,35 @@ using Xunit;
 
 namespace LibraryTests.Nfs
 {
-    public class Nfs3FileSystemInfoTest
+    public class RpcRejectedReplyHeaderTest
     {
         [Fact]
         public void RoundTripTest()
         {
-            Nfs3FileSystemInfo attributes = new Nfs3FileSystemInfo()
+            RpcRejectedReplyHeader header = new RpcRejectedReplyHeader()
             {
-                DirectoryPreferredBytes = 1,
-                FileSystemProperties = Nfs3FileSystemProperties.HardLinks,
-                MaxFileSize = 2,
-                ReadMaxBytes = 3,
-                ReadMultipleSize = 4,
-                ReadPreferredBytes = 5,
-                TimePrecision = Nfs3FileTime.Precision,
-                WriteMaxBytes = 7,
-                WriteMultipleSize = 8,
-                WritePreferredBytes = 9
+                AuthenticationStatus = RpcAuthenticationStatus.None,
+                MismatchInfo = new RpcMismatchInfo()
+                {
+                    High = 1,
+                    Low = 2
+                },
+                Status = RpcRejectedStatus.RpcMismatch
             };
 
-            Nfs3FileSystemInfo clone = null;
+            RpcRejectedReplyHeader clone = null;
 
             using (MemoryStream stream = new MemoryStream())
             {
                 XdrDataWriter writer = new XdrDataWriter(stream);
-                attributes.Write(writer);
+                header.Write(writer);
 
                 stream.Position = 0;
                 XdrDataReader reader = new XdrDataReader(stream);
-                clone = new Nfs3FileSystemInfo(reader);
+                clone = new RpcRejectedReplyHeader(reader);
             }
 
-            Assert.Equal(attributes, clone);
+            Assert.Equal(header, clone);
         }
     }
 }

--- a/Tests/LibraryTests/Nfs/RpcReplyHeaderTest.cs
+++ b/Tests/LibraryTests/Nfs/RpcReplyHeaderTest.cs
@@ -26,38 +26,34 @@ using Xunit;
 
 namespace LibraryTests.Nfs
 {
-    public class Nfs3FileSystemInfoTest
+    public class RpcReplyHeaderTest
     {
         [Fact]
         public void RoundTripTest()
         {
-            Nfs3FileSystemInfo attributes = new Nfs3FileSystemInfo()
+            RpcReplyHeader header = new RpcReplyHeader()
             {
-                DirectoryPreferredBytes = 1,
-                FileSystemProperties = Nfs3FileSystemProperties.HardLinks,
-                MaxFileSize = 2,
-                ReadMaxBytes = 3,
-                ReadMultipleSize = 4,
-                ReadPreferredBytes = 5,
-                TimePrecision = Nfs3FileTime.Precision,
-                WriteMaxBytes = 7,
-                WriteMultipleSize = 8,
-                WritePreferredBytes = 9
+                AcceptReply = new RpcAcceptedReplyHeader()
+                {
+                    AcceptStatus = RpcAcceptStatus.Success,
+                    MismatchInfo = null,
+                    Verifier = new RpcAuthentication(new RpcUnixCredential(1, 2))
+                }
             };
 
-            Nfs3FileSystemInfo clone = null;
+            RpcReplyHeader clone = null;
 
             using (MemoryStream stream = new MemoryStream())
             {
                 XdrDataWriter writer = new XdrDataWriter(stream);
-                attributes.Write(writer);
+                header.Write(writer);
 
                 stream.Position = 0;
                 XdrDataReader reader = new XdrDataReader(stream);
-                clone = new Nfs3FileSystemInfo(reader);
+                clone = new RpcReplyHeader(reader);
             }
 
-            Assert.Equal(attributes, clone);
+            Assert.Equal(header, clone);
         }
     }
 }


### PR DESCRIPTION
The current NFS implementation acts a a client of a NFS server. There's write support for messages which are sent to a NFS server and read support for messages which are received from a NFS server.

This PR adds read/write support for all these messages, which will allow you to build a NFS server using DiscUtils.

Also adds unit tests for roundtripping objects (e.g. serializing & deserializing them).