### PR TITLE
Extract IRpcClient and IRpcTransport interfaces

### DIFF
--- a/Library/DiscUtils.Nfs/IRpcClient.cs
+++ b/Library/DiscUtils.Nfs/IRpcClient.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DiscUtils.Nfs
+{
+    internal interface IRpcClient : IDisposable
+    {
+        RpcCredentials Credentials { get; }
+        IRpcTransport GetTransport(int program, int version);
+        uint NextTransactionId();
+    }
+}

--- a/Library/DiscUtils.Nfs/IRpcTransport.cs
+++ b/Library/DiscUtils.Nfs/IRpcTransport.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DiscUtils.Nfs
+{
+    public interface IRpcTransport : IDisposable
+    {
+        void Send(byte[] message);
+        byte[] SendAndReceive(byte[] message);
+        byte[] Receive();
+    }
+}

--- a/Library/DiscUtils.Nfs/MountProc3.cs
+++ b/Library/DiscUtils.Nfs/MountProc3.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DiscUtils.Nfs
+{
+    // For more information, see
+    // https://www.ietf.org/rfc/rfc1813.txt Appendix I: Mount Protocol
+    internal enum MountProc3 : uint
+    {
+        // Null - Do nothing
+        Null = 0,
+
+        // MNT - Add mount entry
+        Mnt = 1,
+
+        // DUMP - Return mount entries
+        Dump = 2,
+
+        // UMNT - Remove mount entry
+        Umnt = 3,
+
+        // UMNTALL - Remove all mount entries
+        UmntAll = 4,
+
+        // EXPORT - Return export list
+        Export = 5,
+    }
+}

--- a/Library/DiscUtils.Nfs/Nfs3.cs
+++ b/Library/DiscUtils.Nfs/Nfs3.cs
@@ -34,7 +34,7 @@ namespace DiscUtils.Nfs
         public const int CreateVerifierSize = 8;
         public const int WriteVerifierSize = 8;
 
-        public Nfs3(RpcClient client)
+        public Nfs3(IRpcClient client)
             : base(client) {}
 
         public override int Identifier

--- a/Library/DiscUtils.Nfs/Nfs3Client.cs
+++ b/Library/DiscUtils.Nfs/Nfs3Client.cs
@@ -250,7 +250,7 @@ namespace DiscUtils.Nfs
         internal IEnumerable<Nfs3DirectoryEntry> ReadDirectory(Nfs3FileHandle parent, bool silentFail)
         {
             ulong cookie = 0;
-            byte[] cookieVerifier = 0;
+            byte[] cookieVerifier = null;
 
             Nfs3ReadDirPlusResult result;
             do

--- a/Library/DiscUtils.Nfs/Nfs3Client.cs
+++ b/Library/DiscUtils.Nfs/Nfs3Client.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace DiscUtils.Nfs
 {
@@ -32,11 +33,16 @@ namespace DiscUtils.Nfs
         private readonly Nfs3Mount _mountClient;
         private readonly Nfs3 _nfsClient;
 
-        private RpcClient _rpcClient;
+        private IRpcClient _rpcClient;
 
         public Nfs3Client(string address, RpcCredentials credentials, string mountPoint)
+            : this(new RpcClient(address, credentials), mountPoint)
         {
-            _rpcClient = new RpcClient(address, credentials);
+        }
+
+        public Nfs3Client(IRpcClient rpcClient, string mountPoint)
+        {
+            _rpcClient = rpcClient;
             _mountClient = new Nfs3Mount(_rpcClient);
             RootHandle = _mountClient.Mount(mountPoint).FileHandle;
 
@@ -244,7 +250,7 @@ namespace DiscUtils.Nfs
         internal IEnumerable<Nfs3DirectoryEntry> ReadDirectory(Nfs3FileHandle parent, bool silentFail)
         {
             ulong cookie = 0;
-            byte[] cookieVerifier = null;
+            ulong cookieVerifier = 0;
 
             Nfs3ReadDirPlusResult result;
             do

--- a/Library/DiscUtils.Nfs/Nfs3Client.cs
+++ b/Library/DiscUtils.Nfs/Nfs3Client.cs
@@ -250,7 +250,7 @@ namespace DiscUtils.Nfs
         internal IEnumerable<Nfs3DirectoryEntry> ReadDirectory(Nfs3FileHandle parent, bool silentFail)
         {
             ulong cookie = 0;
-            ulong cookieVerifier = 0;
+            byte[] cookieVerifier = 0;
 
             Nfs3ReadDirPlusResult result;
             do

--- a/Library/DiscUtils.Nfs/Nfs3Mount.cs
+++ b/Library/DiscUtils.Nfs/Nfs3Mount.cs
@@ -25,6 +25,8 @@ using System.IO;
 
 namespace DiscUtils.Nfs
 {
+    // For more information, see
+    // https://www.ietf.org/rfc/rfc1813.txt Appendix I: Mount Protocol
     internal sealed class Nfs3Mount : RpcProgram
     {
         public const int ProgramIdentifier = 100005;
@@ -34,8 +36,8 @@ namespace DiscUtils.Nfs
         public const int MaxNameLength = 255;
         public const int MaxFileHandleSize = 64;
 
-        public Nfs3Mount(RpcClient client)
-            : base(client) {}
+        public Nfs3Mount(IRpcClient client)
+            : base(client) { }
 
         public override int Identifier
         {
@@ -50,7 +52,7 @@ namespace DiscUtils.Nfs
         public List<Nfs3Export> Exports()
         {
             MemoryStream ms = new MemoryStream();
-            XdrDataWriter writer = StartCallMessage(ms, null, NfsProc3.Readlink);
+            XdrDataWriter writer = StartCallMessage(ms, null, MountProc3.Export);
 
             RpcReply reply = DoSend(ms);
             if (reply.Header.IsSuccess)
@@ -69,20 +71,15 @@ namespace DiscUtils.Nfs
         public Nfs3MountResult Mount(string dirPath)
         {
             MemoryStream ms = new MemoryStream();
-            XdrDataWriter writer = StartCallMessage(ms, _client.Credentials, NfsProc3.GetAttr);
+            XdrDataWriter writer = StartCallMessage(ms, _client.Credentials, MountProc3.Mnt);
             writer.Write(dirPath);
 
             RpcReply reply = DoSend(ms);
             if (reply.Header.IsSuccess)
             {
-                Nfs3Status status = (Nfs3Status)reply.BodyReader.ReadInt32();
-                if (status == Nfs3Status.Ok)
-                {
-                    return new Nfs3MountResult(reply.BodyReader);
-                }
-
-                throw new Nfs3Exception(status);
+                return new Nfs3MountResult(reply.BodyReader);
             }
+
             throw new RpcException(reply.Header.ReplyHeader);
         }
     }

--- a/Library/DiscUtils.Nfs/NfsProc3.cs
+++ b/Library/DiscUtils.Nfs/NfsProc3.cs
@@ -22,7 +22,7 @@
 
 namespace DiscUtils.Nfs
 {
-    internal enum NfsProc3:uint
+    internal enum NfsProc3 : uint
     {
         Null = 0,
         GetAttr = 1,

--- a/Library/DiscUtils.Nfs/RpcClient.cs
+++ b/Library/DiscUtils.Nfs/RpcClient.cs
@@ -25,7 +25,7 @@ using System.Collections.Generic;
 
 namespace DiscUtils.Nfs
 {
-    internal sealed class RpcClient : IDisposable
+    internal sealed class RpcClient : IRpcClient
     {
         private uint _nextTransaction;
         private readonly string _serverAddress;
@@ -39,7 +39,7 @@ namespace DiscUtils.Nfs
             _transports[PortMapper.ProgramIdentifier] = new RpcTcpTransport(address, 111);
         }
 
-        internal RpcCredentials Credentials { get; }
+        public RpcCredentials Credentials { get; }
 
         public void Dispose()
         {
@@ -54,12 +54,12 @@ namespace DiscUtils.Nfs
             }
         }
 
-        internal uint NextTransactionId()
+        public uint NextTransactionId()
         {
             return _nextTransaction++;
         }
 
-        internal RpcTcpTransport GetTransport(int program, int version)
+        public IRpcTransport GetTransport(int program, int version)
         {
             RpcTcpTransport transport;
             if (!_transports.TryGetValue(program, out transport))

--- a/Library/DiscUtils.Nfs/RpcProgram.cs
+++ b/Library/DiscUtils.Nfs/RpcProgram.cs
@@ -28,9 +28,9 @@ namespace DiscUtils.Nfs
     {
         public const uint RpcVersion = 2;
 
-        protected RpcClient _client;
+        protected IRpcClient _client;
 
-        protected RpcProgram(RpcClient client)
+        protected RpcProgram(IRpcClient client)
         {
             _client = client;
         }
@@ -42,9 +42,9 @@ namespace DiscUtils.Nfs
         public void NullProc()
         {
             MemoryStream ms = new MemoryStream();
-            XdrDataWriter writer = StartCallMessage(ms, null, 0);
+            XdrDataWriter writer = StartCallMessage(ms, null, NfsProc3.Null);
             RpcReply reply = DoSend(ms);
-            if (reply.Header.IsSuccess) {}
+            if (reply.Header.IsSuccess) { }
             else
             {
                 throw new RpcException(reply.Header.ReplyHeader);
@@ -53,14 +53,19 @@ namespace DiscUtils.Nfs
 
         protected RpcReply DoSend(MemoryStream ms)
         {
-            RpcTcpTransport transport = _client.GetTransport(Identifier, Version);
+            IRpcTransport transport = _client.GetTransport(Identifier, Version);
 
             byte[] buffer = ms.ToArray();
-            buffer = transport.Send(buffer);
+            buffer = transport.SendAndReceive(buffer);
 
             XdrDataReader reader = new XdrDataReader(new MemoryStream(buffer));
             RpcMessageHeader header = new RpcMessageHeader(reader);
             return new RpcReply { Header = header, BodyReader = reader };
+        }
+
+        protected XdrDataWriter StartCallMessage(MemoryStream ms, RpcCredentials credentials, MountProc3 procedure)
+        {
+            return StartCallMessage(ms, credentials, (NfsProc3)procedure);
         }
 
         protected XdrDataWriter StartCallMessage(MemoryStream ms, RpcCredentials credentials, NfsProc3 procedure)

--- a/Library/DiscUtils.Nfs/RpcTcpTransport.cs
+++ b/Library/DiscUtils.Nfs/RpcTcpTransport.cs
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2008-2011, Kenneth Bell
+// Copyright (c) 2017, Quamotion
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -30,7 +31,7 @@ using DiscUtils.Streams;
 
 namespace DiscUtils.Nfs
 {
-    internal sealed class RpcTcpTransport : IDisposable
+    internal sealed class RpcTcpTransport : IRpcTransport
     {
         private const int RetryLimit = 20;
 
@@ -69,7 +70,7 @@ namespace DiscUtils.Nfs
             }
         }
 
-        public byte[] Send(byte[] message)
+        public byte[] SendAndReceive(byte[] message)
         {
             int retries = 0;
             int retryLimit = RetryLimit;
@@ -141,11 +142,7 @@ namespace DiscUtils.Nfs
                 {
                     try
                     {
-                        byte[] header = new byte[4];
-                        EndianUtilities.WriteBytesBigEndian(0x80000000 | (uint)message.Length, header, 0);
-                        _tcpStream.Write(header, 0, 4);
-                        _tcpStream.Write(message, 0, message.Length);
-                        _tcpStream.Flush();
+                        Send(_tcpStream, message);
 
                         response = Receive();
                     }
@@ -177,18 +174,37 @@ namespace DiscUtils.Nfs
             return response;
         }
 
-        private byte[] Receive()
+        public void Send(byte[] message)
+        {
+            Send(_tcpStream, message);
+        }
+
+        public static void Send(Stream stream, byte[] message)
+        {
+            byte[] header = new byte[4];
+            EndianUtilities.WriteBytesBigEndian(0x80000000 | (uint)message.Length, header, 0);
+            stream.Write(header, 0, 4);
+            stream.Write(message, 0, message.Length);
+            stream.Flush();
+        }
+
+        public byte[] Receive()
+        {
+            return Receive(_tcpStream);
+        }
+
+        public static byte[] Receive(Stream stream)
         {
             MemoryStream ms = null;
             bool lastFragFound = false;
 
             while (!lastFragFound)
             {
-                byte[] header = StreamUtilities.ReadExact(_tcpStream, 4);
+                byte[] header = StreamUtilities.ReadExact(stream, 4);
                 uint headerVal = EndianUtilities.ToUInt32BigEndian(header, 0);
 
                 lastFragFound = (headerVal & 0x80000000) != 0;
-                byte[] frag = StreamUtilities.ReadExact(_tcpStream, (int)(headerVal & 0x7FFFFFFF));
+                byte[] frag = StreamUtilities.ReadExact(stream, (int)(headerVal & 0x7FFFFFFF));
 
                 if (ms != null)
                 {


### PR DESCRIPTION
Extract an IRpcClient and IRpcTransport interfaces. This allows mocking the RPC client & RPC transport in unit tests.