### PR TITLE
Read/Write support for the remaining NFS classes

### DIFF
--- a/Library/DiscUtils.Nfs/Nfs3AccessPermissions.cs
+++ b/Library/DiscUtils.Nfs/Nfs3AccessPermissions.cs
@@ -25,7 +25,7 @@ using System;
 namespace DiscUtils.Nfs
 {
     [Flags]
-    internal enum Nfs3AccessPermissions
+    public enum Nfs3AccessPermissions
     {
         None = 0x00,
         Read = 0x01,

--- a/Library/DiscUtils.Nfs/Nfs3AccessResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3AccessResult.cs
@@ -22,9 +22,9 @@
 
 namespace DiscUtils.Nfs
 {
-    internal class Nfs3AccessResult : Nfs3CallResult
+    public sealed class Nfs3AccessResult : Nfs3CallResult
     {
-        public Nfs3AccessResult(XdrDataReader reader)
+        internal Nfs3AccessResult(XdrDataReader reader)
         {
             Status = (Nfs3Status)reader.ReadInt32();
             if (reader.ReadBool())

--- a/Library/DiscUtils.Nfs/Nfs3CallResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3CallResult.cs
@@ -27,11 +27,11 @@ namespace DiscUtils.Nfs
     /// <summary>
     /// Base class for all NFS result structures.
     /// </summary>
-    internal abstract class Nfs3CallResult
+    public abstract class Nfs3CallResult
     {
         public Nfs3Status Status { get; set; }
 
-        public virtual void Write(XdrDataWriter writer)
+        internal virtual void Write(XdrDataWriter writer)
         {
             throw new NotSupportedException();
         }

--- a/Library/DiscUtils.Nfs/Nfs3CreateResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3CreateResult.cs
@@ -20,6 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     internal class Nfs3CreateResult : Nfs3CallResult
@@ -43,10 +45,59 @@ namespace DiscUtils.Nfs
             CacheConsistency = new Nfs3WeakCacheConsistency(reader);
         }
 
+        public Nfs3CreateResult()
+        {
+        }
+
         public Nfs3WeakCacheConsistency CacheConsistency { get; set; }
 
         public Nfs3FileAttributes FileAttributes { get; set; }
 
         public Nfs3FileHandle FileHandle { get; set; }
+
+        internal override void Write(XdrDataWriter writer)
+        {
+            writer.Write((int)Status);
+
+            if (Status == Nfs3Status.Ok)
+            {
+                writer.Write(FileHandle != null);
+                if (FileHandle != null)
+                {
+                    FileHandle.Write(writer);
+                }
+
+                writer.Write(FileAttributes != null);
+                if (FileAttributes != null)
+                {
+                    FileAttributes.Write(writer);
+                }
+            }
+
+            CacheConsistency.Write(writer);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3CreateResult);
+        }
+
+        public bool Equals(Nfs3CreateResult other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Status == Status
+                && object.Equals(other.FileHandle, FileHandle)
+                && object.Equals(other.FileAttributes, FileAttributes)
+                && object.Equals(other.CacheConsistency, CacheConsistency);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Status, FileHandle, FileAttributes, CacheConsistency);
+        }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3CreateResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3CreateResult.cs
@@ -24,9 +24,9 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal class Nfs3CreateResult : Nfs3CallResult
+    public class Nfs3CreateResult : Nfs3CallResult
     {
-        public Nfs3CreateResult(XdrDataReader reader)
+        internal Nfs3CreateResult(XdrDataReader reader)
         {
             Status = (Nfs3Status)reader.ReadInt32();
             if (Status == Nfs3Status.Ok)

--- a/Library/DiscUtils.Nfs/Nfs3DirectoryEntry.cs
+++ b/Library/DiscUtils.Nfs/Nfs3DirectoryEntry.cs
@@ -24,9 +24,9 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal class Nfs3DirectoryEntry
+    public sealed class Nfs3DirectoryEntry
     {
-        public Nfs3DirectoryEntry(XdrDataReader reader)
+        internal Nfs3DirectoryEntry(XdrDataReader reader)
         {
             FileId = reader.ReadUInt64();
             Name = reader.ReadString();
@@ -56,7 +56,7 @@ namespace DiscUtils.Nfs
 
         public string Name { get; set; }
 
-        public void Write(XdrDataWriter writer)
+        internal void Write(XdrDataWriter writer)
         {
             writer.Write(FileId);
             writer.Write(Name);

--- a/Library/DiscUtils.Nfs/Nfs3Export.cs
+++ b/Library/DiscUtils.Nfs/Nfs3Export.cs
@@ -27,7 +27,7 @@ namespace DiscUtils.Nfs
 {
     public sealed class Nfs3Export
     {
-        public Nfs3Export(XdrDataReader reader)
+        internal Nfs3Export(XdrDataReader reader)
         {
             DirPath = reader.ReadString(Nfs3Mount.MaxPathLength);
 

--- a/Library/DiscUtils.Nfs/Nfs3Export.cs
+++ b/Library/DiscUtils.Nfs/Nfs3Export.cs
@@ -27,7 +27,7 @@ namespace DiscUtils.Nfs
 {
     public sealed class Nfs3Export
     {
-        internal Nfs3Export(XdrDataReader reader)
+        public Nfs3Export(XdrDataReader reader)
         {
             DirPath = reader.ReadString(Nfs3Mount.MaxPathLength);
 

--- a/Library/DiscUtils.Nfs/Nfs3Export.cs
+++ b/Library/DiscUtils.Nfs/Nfs3Export.cs
@@ -20,11 +20,12 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
 using System.Collections.Generic;
 
 namespace DiscUtils.Nfs
 {
-    internal sealed class Nfs3Export
+    public sealed class Nfs3Export
     {
         internal Nfs3Export(XdrDataReader reader)
         {
@@ -39,8 +40,63 @@ namespace DiscUtils.Nfs
             Groups = groups;
         }
 
+        public Nfs3Export()
+        {
+        }
+
         public string DirPath { get; set; }
 
         public List<string> Groups { get; set; }
+
+        internal void Write(XdrDataWriter writer)
+        {
+            writer.Write(DirPath);
+
+            foreach (var group in Groups)
+            {
+                writer.Write(true);
+                writer.Write(group);
+            }
+
+            writer.Write(false);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3Export);
+        }
+
+        public bool Equals(Nfs3Export other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (!string.Equals(other.DirPath, DirPath))
+            {
+                return false;
+            }
+
+            if (other.Groups == null || Groups == null)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < Groups.Count; i++)
+            {
+                if (!string.Equals(other.Groups[i], Groups[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(DirPath, Groups);
+        }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3FileAttributes.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileAttributes.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal class Nfs3FileAttributes
+    public sealed class Nfs3FileAttributes
     {
         public Nfs3FileTime AccessTime;
         public long BytesUsed;
@@ -45,7 +45,7 @@ namespace DiscUtils.Nfs
         {
         }
 
-        public Nfs3FileAttributes(XdrDataReader reader)
+        internal Nfs3FileAttributes(XdrDataReader reader)
         {
             Type = (Nfs3FileType)reader.ReadInt32();
             Mode = (UnixFilePermissions)reader.ReadInt32();
@@ -63,7 +63,7 @@ namespace DiscUtils.Nfs
             ChangeTime = new Nfs3FileTime(reader);
         }
 
-        public void Write(XdrDataWriter writer)
+        internal void Write(XdrDataWriter writer)
         {
             writer.Write((int)Type);
             writer.Write((int)Mode);

--- a/Library/DiscUtils.Nfs/Nfs3FileHandle.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileHandle.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal sealed class Nfs3FileHandle : IEquatable<Nfs3FileHandle>, IComparable<Nfs3FileHandle>
+    public sealed class Nfs3FileHandle : IEquatable<Nfs3FileHandle>, IComparable<Nfs3FileHandle>
     {
         public Nfs3FileHandle()
         {

--- a/Library/DiscUtils.Nfs/Nfs3FileSystemInfo.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileSystemInfo.cs
@@ -24,9 +24,9 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal sealed class Nfs3FileSystemInfo
+    public sealed class Nfs3FileSystemInfo
     {
-        public Nfs3FileSystemInfo(XdrDataReader reader)
+        internal Nfs3FileSystemInfo(XdrDataReader reader)
         {
             ReadMaxBytes = reader.ReadUInt32();
             ReadPreferredBytes = reader.ReadUInt32();
@@ -111,7 +111,7 @@ namespace DiscUtils.Nfs
         /// </summary>
         public uint WritePreferredBytes { get; set; }
 
-        public void Write(XdrDataWriter writer)
+        internal void Write(XdrDataWriter writer)
         {
             writer.Write(ReadMaxBytes);
             writer.Write(ReadPreferredBytes);

--- a/Library/DiscUtils.Nfs/Nfs3FileSystemInfoResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileSystemInfoResult.cs
@@ -24,9 +24,9 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal class Nfs3FileSystemInfoResult : Nfs3CallResult
+    public sealed class Nfs3FileSystemInfoResult : Nfs3CallResult
     {
-        public Nfs3FileSystemInfoResult(XdrDataReader reader)
+        internal Nfs3FileSystemInfoResult(XdrDataReader reader)
         {
             Status = (Nfs3Status)reader.ReadInt32();
             if (reader.ReadBool())
@@ -48,7 +48,7 @@ namespace DiscUtils.Nfs
 
         public Nfs3FileAttributes PostOpAttributes { get; set; }
 
-        public override void Write(XdrDataWriter writer)
+        internal override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
 

--- a/Library/DiscUtils.Nfs/Nfs3FileSystemProperties.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileSystemProperties.cs
@@ -25,7 +25,7 @@ using System;
 namespace DiscUtils.Nfs
 {
     [Flags]
-    internal enum Nfs3FileSystemProperties
+    public enum Nfs3FileSystemProperties
     {
         None = 0,
         HardLinks = 1,

--- a/Library/DiscUtils.Nfs/Nfs3FileSystemStat.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileSystemStat.cs
@@ -24,9 +24,9 @@ namespace DiscUtils.Nfs
 {
     using System;
 
-    internal sealed class Nfs3FileSystemStat
+    public sealed class Nfs3FileSystemStat
     {
-        public Nfs3FileSystemStat(XdrDataReader reader)
+        internal Nfs3FileSystemStat(XdrDataReader reader)
         {
             TotalSizeBytes = reader.ReadUInt64();
             FreeSpaceBytes = reader.ReadUInt64();

--- a/Library/DiscUtils.Nfs/Nfs3FileSystemStatResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileSystemStatResult.cs
@@ -22,9 +22,9 @@
 
 namespace DiscUtils.Nfs
 {
-    internal class Nfs3FileSystemStatResult : Nfs3CallResult
+    public class Nfs3FileSystemStatResult : Nfs3CallResult
     {
-        public Nfs3FileSystemStatResult(XdrDataReader reader)
+        internal Nfs3FileSystemStatResult(XdrDataReader reader)
         {
             Status = (Nfs3Status)reader.ReadInt32();
             if (reader.ReadBool())

--- a/Library/DiscUtils.Nfs/Nfs3FileTime.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileTime.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal class Nfs3FileTime
+    public sealed class Nfs3FileTime
     {
         private const long TicksPerSec = 10 * 1000 * 1000; // 10 million ticks per sec
         private const long TicksPerNanoSec = 100; // 1 tick = 100 ns
@@ -34,7 +34,7 @@ namespace DiscUtils.Nfs
 
         private readonly uint _seconds;
 
-        public Nfs3FileTime(XdrDataReader reader)
+        internal Nfs3FileTime(XdrDataReader reader)
         {
             _seconds = reader.ReadUInt32();
             _nseconds = reader.ReadUInt32();
@@ -53,24 +53,12 @@ namespace DiscUtils.Nfs
             _nseconds = nseconds;
         }
 
-        ////public Nfs3FileTime(TimeSpan timeSpan)
-        ////{
-        ////    long ticks = timeSpan.Ticks;
-        ////    _seconds = (uint)(ticks / TicksPerSec);
-        ////    _nseconds = (uint)((ticks % TicksPerSec) * TicksPerNanoSec);
-        ////}
-
         public DateTime ToDateTime()
         {
             return new DateTime(_seconds * TicksPerSec + _nseconds / TicksPerNanoSec + nfsEpoch.Ticks);
         }
 
-        ////public TimeSpan ToTimeSpan()
-        ////{
-        ////    return new TimeSpan(_seconds * TicksPerSec + (_nseconds / TicksPerNanoSec));
-        ////}
-
-        public void Write(XdrDataWriter writer)
+        internal void Write(XdrDataWriter writer)
         {
             writer.Write(_seconds);
             writer.Write(_nseconds);

--- a/Library/DiscUtils.Nfs/Nfs3FileType.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileType.cs
@@ -22,7 +22,7 @@
 
 namespace DiscUtils.Nfs
 {
-    internal enum Nfs3FileType
+    public enum Nfs3FileType
     {
         None = 0,
         File = 1,

--- a/Library/DiscUtils.Nfs/Nfs3GetAttributesResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3GetAttributesResult.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal class Nfs3GetAttributesResult : Nfs3CallResult
+    public class Nfs3GetAttributesResult : Nfs3CallResult
     {
         public Nfs3GetAttributesResult()
         {

--- a/Library/DiscUtils.Nfs/Nfs3GetAttributesResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3GetAttributesResult.cs
@@ -20,16 +20,49 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     internal class Nfs3GetAttributesResult : Nfs3CallResult
     {
-        public Nfs3GetAttributesResult(XdrDataReader reader)
+        public Nfs3GetAttributesResult()
+        {
+        }
+
+        internal Nfs3GetAttributesResult(XdrDataReader reader)
         {
             Status = (Nfs3Status)reader.ReadInt32();
             Attributes = new Nfs3FileAttributes(reader);
         }
 
         public Nfs3FileAttributes Attributes { get; set; }
+
+        internal override void Write(XdrDataWriter writer)
+        {
+            writer.Write((int)Status);
+            Attributes.Write(writer);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3GetAttributesResult);
+        }
+
+        public bool Equals(Nfs3GetAttributesResult other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Status == Status
+                && object.Equals(other.Attributes, Attributes);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Status, Attributes);
+        }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3LookupResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3LookupResult.cs
@@ -24,13 +24,13 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal class Nfs3LookupResult : Nfs3CallResult
+    public sealed class Nfs3LookupResult : Nfs3CallResult
     {
         public Nfs3LookupResult()
         {
         }
 
-        public Nfs3LookupResult(XdrDataReader reader)
+        internal Nfs3LookupResult(XdrDataReader reader)
         {
             Status = (Nfs3Status)reader.ReadInt32();
             if (Status == Nfs3Status.Ok)
@@ -54,7 +54,7 @@ namespace DiscUtils.Nfs
 
         public Nfs3FileHandle ObjectHandle { get; set; }
 
-        public override void Write(XdrDataWriter writer)
+        internal override void Write(XdrDataWriter writer)
         {
             writer.Write((int)this.Status);
 

--- a/Library/DiscUtils.Nfs/Nfs3MountResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3MountResult.cs
@@ -28,9 +28,9 @@ using System.Linq;
 
 namespace DiscUtils.Nfs
 {
-    internal sealed class Nfs3MountResult : Nfs3CallResult
+    public sealed class Nfs3MountResult : Nfs3CallResult
     {
-        public Nfs3MountResult(XdrDataReader reader)
+        internal Nfs3MountResult(XdrDataReader reader)
         {
             Status = (Nfs3Status)reader.ReadInt32();
 
@@ -58,7 +58,7 @@ namespace DiscUtils.Nfs
 
         public Nfs3FileHandle FileHandle { get; set; }
 
-        public override void Write(XdrDataWriter writer)
+        internal override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
 

--- a/Library/DiscUtils.Nfs/Nfs3ReadDirPlusResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3ReadDirPlusResult.cs
@@ -28,9 +28,9 @@ using System.Linq;
 
 namespace DiscUtils.Nfs
 {
-    internal class Nfs3ReadDirPlusResult : Nfs3CallResult
+    public sealed class Nfs3ReadDirPlusResult : Nfs3CallResult
     {
-        public Nfs3ReadDirPlusResult(XdrDataReader reader)
+        internal Nfs3ReadDirPlusResult(XdrDataReader reader)
         {
             Status = (Nfs3Status)reader.ReadInt32();
             if (reader.ReadBool())
@@ -65,7 +65,7 @@ namespace DiscUtils.Nfs
 
         public bool Eof { get; set; }
 
-        public override void Write(XdrDataWriter writer)
+        internal override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
 

--- a/Library/DiscUtils.Nfs/Nfs3ReadResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3ReadResult.cs
@@ -27,9 +27,9 @@ using System.Linq;
 
 namespace DiscUtils.Nfs
 {
-    internal class Nfs3ReadResult : Nfs3CallResult
+    public sealed class Nfs3ReadResult : Nfs3CallResult
     {
-        public Nfs3ReadResult(XdrDataReader reader)
+        internal Nfs3ReadResult(XdrDataReader reader)
         {
             Status = (Nfs3Status)reader.ReadInt32();
             if (reader.ReadBool())
@@ -57,7 +57,7 @@ namespace DiscUtils.Nfs
 
         public Nfs3FileAttributes FileAttributes { get; set; }
 
-        public override void Write(XdrDataWriter writer)
+        internal override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
 

--- a/Library/DiscUtils.Nfs/Nfs3RenameResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3RenameResult.cs
@@ -22,9 +22,9 @@
 
 namespace DiscUtils.Nfs
 {
-    internal sealed class Nfs3RenameResult : Nfs3CallResult
+    public sealed class Nfs3RenameResult : Nfs3CallResult
     {
-        public Nfs3RenameResult(XdrDataReader reader)
+        internal Nfs3RenameResult(XdrDataReader reader)
         {
             Status = (Nfs3Status)reader.ReadInt32();
             FromDirCacheConsistency = new Nfs3WeakCacheConsistency(reader);

--- a/Library/DiscUtils.Nfs/Nfs3SetAttributes.cs
+++ b/Library/DiscUtils.Nfs/Nfs3SetAttributes.cs
@@ -24,13 +24,13 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal sealed class Nfs3SetAttributes
+    public sealed class Nfs3SetAttributes
     {
         public Nfs3SetAttributes()
         {
         }
 
-        public Nfs3SetAttributes(XdrDataReader reader)
+        internal Nfs3SetAttributes(XdrDataReader reader)
         {
             SetMode = reader.ReadBool();
 
@@ -93,7 +93,7 @@ namespace DiscUtils.Nfs
 
         public uint Uid { get; set; }
 
-        public void Write(XdrDataWriter writer)
+        internal void Write(XdrDataWriter writer)
         {
             writer.Write(SetMode);
             if (SetMode)

--- a/Library/DiscUtils.Nfs/Nfs3SetTimeMethod.cs
+++ b/Library/DiscUtils.Nfs/Nfs3SetTimeMethod.cs
@@ -1,6 +1,6 @@
 namespace DiscUtils.Nfs
 {
-    internal enum Nfs3SetTimeMethod
+    public enum Nfs3SetTimeMethod
     {
         NoChange = 0,
         ServerTime = 1,

--- a/Library/DiscUtils.Nfs/Nfs3StableHow.cs
+++ b/Library/DiscUtils.Nfs/Nfs3StableHow.cs
@@ -1,0 +1,32 @@
+﻿//
+// Copyright (c) 2017, Kenneth Bell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+
+namespace DiscUtils.Nfs
+{
+    public enum Nfs3StableHow : uint
+    {
+        Unstable = 0,
+        DataSync = 1,
+        FileSynce = 2
+    }
+}

--- a/Library/DiscUtils.Nfs/Nfs3WeakCacheConsistency.cs
+++ b/Library/DiscUtils.Nfs/Nfs3WeakCacheConsistency.cs
@@ -24,9 +24,9 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal sealed class Nfs3WeakCacheConsistency
+    public sealed class Nfs3WeakCacheConsistency
     {
-        public Nfs3WeakCacheConsistency(XdrDataReader reader)
+        internal Nfs3WeakCacheConsistency(XdrDataReader reader)
         {
             if (reader.ReadBool())
             {
@@ -47,7 +47,7 @@ namespace DiscUtils.Nfs
 
         public Nfs3WeakCacheConsistencyAttr Before { get; set; }
 
-        public void Write(XdrDataWriter writer)
+        internal void Write(XdrDataWriter writer)
         {
             writer.Write(Before != null);
             if (Before != null)

--- a/Library/DiscUtils.Nfs/Nfs3WeakCacheConsistencyAttr.cs
+++ b/Library/DiscUtils.Nfs/Nfs3WeakCacheConsistencyAttr.cs
@@ -24,9 +24,9 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal sealed class Nfs3WeakCacheConsistencyAttr
+    public sealed class Nfs3WeakCacheConsistencyAttr
     {
-        public Nfs3WeakCacheConsistencyAttr(XdrDataReader reader)
+        internal Nfs3WeakCacheConsistencyAttr(XdrDataReader reader)
         {
             Size = reader.ReadInt64();
             ModifyTime = new Nfs3FileTime(reader);
@@ -43,7 +43,7 @@ namespace DiscUtils.Nfs
 
         public long Size { get; set; }
 
-        public void Write(XdrDataWriter writer)
+        internal void Write(XdrDataWriter writer)
         {
             writer.Write(Size);
             ModifyTime.Write(writer);

--- a/Library/DiscUtils.Nfs/Nfs3WriteResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3WriteResult.cs
@@ -26,9 +26,9 @@ using System.Linq;
 
 namespace DiscUtils.Nfs
 {
-    internal class Nfs3WriteResult : Nfs3CallResult
+    public sealed class Nfs3WriteResult : Nfs3CallResult
     {
-        public Nfs3WriteResult(XdrDataReader reader)
+        internal Nfs3WriteResult(XdrDataReader reader)
         {
             Status = (Nfs3Status)reader.ReadInt32();
             CacheConsistency = new Nfs3WeakCacheConsistency(reader);
@@ -52,7 +52,7 @@ namespace DiscUtils.Nfs
 
         public ulong WriteVerifier { get; set; }
 
-        public override void Write(XdrDataWriter writer)
+        internal override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
             CacheConsistency.Write(writer);

--- a/Library/DiscUtils.Nfs/Nfs3WriteResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3WriteResult.cs
@@ -35,7 +35,7 @@ namespace DiscUtils.Nfs
             if (Status == Nfs3Status.Ok)
             {
                 Count = reader.ReadInt32();
-                HowCommitted = reader.ReadInt32();
+                HowCommitted = (Nfs3StableHow)reader.ReadInt32();
                 WriteVerifier = reader.ReadUInt64();
             }
         }
@@ -48,7 +48,7 @@ namespace DiscUtils.Nfs
 
         public int Count { get; set; }
 
-        public int HowCommitted { get; set; }
+        public Nfs3StableHow HowCommitted { get; set; }
 
         public ulong WriteVerifier { get; set; }
 
@@ -59,7 +59,7 @@ namespace DiscUtils.Nfs
             if(Status == Nfs3Status.Ok)
             {
                 writer.Write(Count);
-                writer.Write(HowCommitted);
+                writer.Write((int)HowCommitted);
                 writer.Write(WriteVerifier);
             }
         }

--- a/Library/DiscUtils.Nfs/Nfs3WriteResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3WriteResult.cs
@@ -20,6 +20,7 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
 #if !NET20
 using System.Linq;
 #endif
@@ -81,6 +82,11 @@ namespace DiscUtils.Nfs
                 && other.Count == Count
                 && other.WriteVerifier == WriteVerifier
                 && other.HowCommitted == HowCommitted;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Status, CacheConsistency, Count, WriteVerifier, HowCommitted);
         }
     }
 }

--- a/Library/DiscUtils.Nfs/RpcAuthFlavour.cs
+++ b/Library/DiscUtils.Nfs/RpcAuthFlavour.cs
@@ -1,6 +1,6 @@
 namespace DiscUtils.Nfs
 {
-    internal enum RpcAuthFlavour
+    public enum RpcAuthFlavour : int
     {
         Null = 0,
         Unix = 1,

--- a/Tests/LibraryTests/Nfs/Nfs3CreateResultTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3CreateResultTest.cs
@@ -1,0 +1,56 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using DiscUtils.Nfs;
+using System.IO;
+using Xunit;
+
+namespace LibraryTests.Nfs
+{
+    public class Nfs3CreateResultTest
+    {
+        [Fact]
+        public void RoundTripTest()
+        {
+            Nfs3CreateResult result = new Nfs3CreateResult()
+            {
+                Status = Nfs3Status.Ok,
+                FileHandle = new Nfs3FileHandle() { Value = new byte[] { 0xab, 0xcd } },
+                CacheConsistency = new Nfs3WeakCacheConsistency()
+            };
+
+            Nfs3CreateResult clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                result.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new Nfs3CreateResult(reader);
+            }
+
+            Assert.Equal(result, clone);
+        }
+    }
+}

--- a/Tests/LibraryTests/Nfs/Nfs3ExportResultTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3ExportResultTest.cs
@@ -1,0 +1,66 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using DiscUtils.Nfs;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace LibraryTests.Nfs
+{
+    public class Nfs3ExportResultTest
+    {
+        [Fact]
+        public void RoundTripTest()
+        {
+            Nfs3ExportResult result = new Nfs3ExportResult()
+            {
+                Exports = new List<Nfs3Export>()
+                 {
+                      new Nfs3Export()
+                      {
+                           DirPath = "export",
+                           Groups = new List<string>()
+                           {
+                                "GroupA",
+                                "GroupB"
+                           }
+                      }
+                 }
+            };
+
+            Nfs3ExportResult clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                result.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new Nfs3ExportResult(reader);
+            }
+
+            Assert.Equal(result, clone);
+        }
+    }
+}

--- a/Tests/LibraryTests/Nfs/Nfs3ExportTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3ExportTest.cs
@@ -1,0 +1,60 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using DiscUtils.Nfs;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace LibraryTests.Nfs
+{
+    public class Nfs3ExportTest
+    {
+        [Fact]
+        public void RoundTripTest()
+        {
+            Nfs3Export export = new Nfs3Export()
+            {
+                DirPath = "test",
+                Groups = new List<string>()
+                  {
+                      "Group1",
+                      "Group2"
+                  }
+            };
+
+            Nfs3Export clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                export.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new Nfs3Export(reader);
+            }
+
+            Assert.Equal(export, clone);
+        }
+    }
+}

--- a/Tests/LibraryTests/Nfs/Nfs3GetAttributesResultTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3GetAttributesResultTest.cs
@@ -20,7 +20,6 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using DiscUtils;
 using DiscUtils.Nfs;
 using System;
 using System.IO;
@@ -28,46 +27,23 @@ using Xunit;
 
 namespace LibraryTests.Nfs
 {
-    public class Nfs3WriteResultTest
+    public class Nfs3GetAttributesResultTest
     {
         [Fact]
         public void RoundTripTest()
         {
-            Nfs3WriteResult result = new Nfs3WriteResult()
+            Nfs3GetAttributesResult result = new Nfs3GetAttributesResult()
             {
-                CacheConsistency = new Nfs3WeakCacheConsistency()
+                Attributes = new Nfs3FileAttributes()
                 {
-                    Before = new Nfs3WeakCacheConsistencyAttr()
-                    {
-                        ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
-                        ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
-                        Size = 3
-                    },
-                    After = new Nfs3FileAttributes()
-                    {
-                        AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
-                        BytesUsed = 2,
-                        ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
-                        FileId = 3,
-                        FileSystemId = 4,
-                        Gid = 5,
-                        LinkCount = 6,
-                        Mode = UnixFilePermissions.GroupAll,
-                        ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 3)),
-                        RdevMajor = 7,
-                        RdevMinor = 8,
-                        Size = 9,
-                        Type = Nfs3FileType.NamedPipe,
-                        Uid = 10
-                    }
+                    AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
+                    ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
+                    ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 3))
                 },
-                Count = 1,
-                HowCommitted = Nfs3StableHow.Unstable,
-                Status = Nfs3Status.Ok,
-                WriteVerifier = 3
+                Status = Nfs3Status.Ok
             };
 
-            Nfs3WriteResult clone = null;
+            Nfs3GetAttributesResult clone = null;
 
             using (MemoryStream stream = new MemoryStream())
             {
@@ -76,7 +52,7 @@ namespace LibraryTests.Nfs
 
                 stream.Position = 0;
                 XdrDataReader reader = new XdrDataReader(stream);
-                clone = new Nfs3WriteResult(reader);
+                clone = new Nfs3GetAttributesResult(reader);
             }
 
             Assert.Equal(result, clone);

--- a/Tests/LibraryTests/Nfs/Nfs3ModifyResultTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3ModifyResultTest.cs
@@ -1,5 +1,5 @@
-//
-// Copyright (c) 2008-2011, Kenneth Bell
+﻿//
+// Copyright (c) 2017, Quamotion
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,49 +20,36 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using System;
+using DiscUtils.Nfs;
+using System.IO;
+using Xunit;
 
-namespace DiscUtils.Nfs
+namespace LibraryTests.Nfs
 {
-    internal sealed class Nfs3ModifyResult : Nfs3CallResult
+    public class Nfs3ModifyResultTest
     {
-        public Nfs3ModifyResult()
+        [Fact]
+        public void RoundTripTest()
         {
-        }
-
-        internal Nfs3ModifyResult(XdrDataReader reader)
-        {
-            Status = (Nfs3Status)reader.ReadInt32();
-            CacheConsistency = new Nfs3WeakCacheConsistency(reader);
-        }
-
-        public Nfs3WeakCacheConsistency CacheConsistency { get; set; }
-
-        internal override void Write(XdrDataWriter writer)
-        {
-            writer.Write((int)Status);
-            CacheConsistency.Write(writer);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as Nfs3ModifyResult);
-        }
-
-        public bool Equals(Nfs3ModifyResult other)
-        {
-            if(other == null)
+            Nfs3ModifyResult result = new Nfs3ModifyResult()
             {
-                return false;
+                CacheConsistency = new Nfs3WeakCacheConsistency(),
+                Status = Nfs3Status.Ok
+            };
+
+            Nfs3ModifyResult clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                result.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new Nfs3ModifyResult(reader);
             }
 
-            return other.Status == Status
-                && object.Equals(other.CacheConsistency, CacheConsistency);
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Status, CacheConsistency);
+            Assert.Equal(result, clone);
         }
     }
 }


### PR DESCRIPTION
A continuation of #83, this adds read/write support to the the other NFS classes.
Basic unit tests have been added, they make sure the data roundtrips correctly when serialized.

Adds a missing `Nfs3StableHow` enum.

It also marks all of the classes used by RPC calls in NFS as public, this allows a you to implement a NFS server on top of DiscUtils. The constructors which take an `XdrDataReader` and `Write` methods are kept internal and the classes are sealed.

