### PR TITLE
NFS: Make FileSystemStat, FileSystemStatResult read/write

### DIFF
--- a/Library/DiscUtils.Nfs/Nfs3.cs
+++ b/Library/DiscUtils.Nfs/Nfs3.cs
@@ -131,7 +131,7 @@ namespace DiscUtils.Nfs
             handle.Write(writer);
             writer.Write(position);
             writer.Write(count);
-            writer.Write(0); // UNSTABLE
+            writer.Write((int)Nfs3StableHow.Unstable);
             writer.WriteBuffer(buffer, bufferOffset, count);
 
             RpcReply reply = DoSend(ms);

--- a/Library/DiscUtils.Nfs/Nfs3Export.cs
+++ b/Library/DiscUtils.Nfs/Nfs3Export.cs
@@ -27,7 +27,7 @@ namespace DiscUtils.Nfs
 {
     public sealed class Nfs3Export
     {
-        public Nfs3Export(XdrDataReader reader)
+        internal Nfs3Export(XdrDataReader reader)
         {
             DirPath = reader.ReadString(Nfs3Mount.MaxPathLength);
 

--- a/Library/DiscUtils.Nfs/Nfs3Export.cs
+++ b/Library/DiscUtils.Nfs/Nfs3Export.cs
@@ -27,7 +27,7 @@ namespace DiscUtils.Nfs
 {
     public sealed class Nfs3Export
     {
-        internal Nfs3Export(XdrDataReader reader)
+        public Nfs3Export(XdrDataReader reader)
         {
             DirPath = reader.ReadString(Nfs3Mount.MaxPathLength);
 

--- a/Library/DiscUtils.Nfs/Nfs3FileSystemStat.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileSystemStat.cs
@@ -26,6 +26,10 @@ namespace DiscUtils.Nfs
 
     public sealed class Nfs3FileSystemStat
     {
+        public Nfs3FileSystemStat()
+        {
+        }
+
         internal Nfs3FileSystemStat(XdrDataReader reader)
         {
             TotalSizeBytes = reader.ReadUInt64();
@@ -105,5 +109,50 @@ namespace DiscUtils.Nfs
         public TimeSpan Invariant { get; set; }
 
         public DateTime InvariantUntil { get; private set; }
+
+        internal void Write(XdrDataWriter writer)
+        {
+            writer.Write(TotalSizeBytes);
+            writer.Write(FreeSpaceBytes);
+            writer.Write(AvailableFreeSpaceBytes);
+            writer.Write(FileSlotCount);
+            writer.Write(FreeFileSlotCount);
+            writer.Write(AvailableFreeFileSlotCount);
+
+            if (Invariant == TimeSpan.MaxValue)
+            {
+                writer.Write(uint.MaxValue);
+            }
+            else
+            {
+                writer.Write((uint)Invariant.TotalSeconds);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3FileSystemStat);
+        }
+
+        public bool Equals(Nfs3FileSystemStat other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.TotalSizeBytes == TotalSizeBytes
+                && other.FreeSpaceBytes == FreeSpaceBytes
+                && other.AvailableFreeSpaceBytes == AvailableFreeSpaceBytes
+                && other.FileSlotCount == FileSlotCount
+                && other.FreeFileSlotCount == FreeFileSlotCount
+                && other.AvailableFreeFileSlotCount == AvailableFreeFileSlotCount
+                && other.Invariant == Invariant;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(TotalSizeBytes, FreeSpaceBytes, AvailableFreeSpaceBytes, FileSlotCount, FreeFileSlotCount, AvailableFreeFileSlotCount, Invariant);
+        }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3FileSystemStatResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileSystemStatResult.cs
@@ -20,10 +20,16 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     public class Nfs3FileSystemStatResult : Nfs3CallResult
     {
+        public Nfs3FileSystemStatResult()
+        {
+        }
+
         internal Nfs3FileSystemStatResult(XdrDataReader reader)
         {
             Status = (Nfs3Status)reader.ReadInt32();
@@ -41,5 +47,43 @@ namespace DiscUtils.Nfs
         public Nfs3FileAttributes PostOpAttributes { get; set; }
 
         public Nfs3FileSystemStat FileSystemStat { get; set; }
+
+        internal override void Write(XdrDataWriter writer)
+        {
+            writer.Write((int)Status);
+
+            writer.Write(PostOpAttributes != null);
+            if (PostOpAttributes != null)
+            {
+                PostOpAttributes.Write(writer);
+            }
+
+            if (Status == Nfs3Status.Ok)
+            {
+                FileSystemStat.Write(writer);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3FileSystemStatResult);
+        }
+
+        public bool Equals(Nfs3FileSystemStatResult other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Status == Status
+                && object.Equals(other.PostOpAttributes, PostOpAttributes)
+                && object.Equals(other.FileSystemStat, FileSystemStat);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Status, PostOpAttributes, FileSystemStat);
+        }
     }
 }

--- a/Tests/LibraryTests/Nfs/Nfs3FileSystemStatResultTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3FileSystemStatResultTest.cs
@@ -1,0 +1,70 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using DiscUtils.Nfs;
+using System;
+using System.IO;
+using Xunit;
+
+namespace LibraryTests.Nfs
+{
+    public class Nfs3FileSystemStatResultTest
+    {
+        [Fact]
+        public void RoundTripTest()
+        {
+            Nfs3FileSystemStatResult result = new Nfs3FileSystemStatResult()
+            {
+                FileSystemStat = new Nfs3FileSystemStat()
+                {
+                    AvailableFreeFileSlotCount = 1,
+                    AvailableFreeSpaceBytes = 2,
+                    FileSlotCount = 3,
+                    FreeFileSlotCount = 4,
+                    FreeSpaceBytes = 5,
+                    Invariant = TimeSpan.FromSeconds(7),
+                    TotalSizeBytes = 8
+                },
+                PostOpAttributes = new Nfs3FileAttributes()
+                {
+                    AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
+                    ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
+                    ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 3))
+                }
+            };
+
+            Nfs3FileSystemStatResult clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                result.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new Nfs3FileSystemStatResult(reader);
+            }
+
+            Assert.Equal(result, clone);
+        }
+    }
+}

--- a/Tests/LibraryTests/Nfs/Nfs3FileSystemStatTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3FileSystemStatTest.cs
@@ -1,0 +1,61 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using DiscUtils.Nfs;
+using System;
+using System.IO;
+using Xunit;
+
+namespace LibraryTests.Nfs
+{
+    public class Nfs3FileSystemStatTest
+    {
+        [Fact]
+        public void RoundTripTest()
+        {
+            Nfs3FileSystemStat attributes = new Nfs3FileSystemStat()
+            {
+                AvailableFreeFileSlotCount = 1,
+                AvailableFreeSpaceBytes = 2,
+                FileSlotCount = 3,
+                FreeFileSlotCount = 4,
+                FreeSpaceBytes = 5,
+                Invariant = TimeSpan.FromSeconds(7),
+                TotalSizeBytes = 8
+            };
+
+            Nfs3FileSystemStat clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                attributes.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new Nfs3FileSystemStat(reader);
+            }
+
+            Assert.Equal(attributes, clone);
+        }
+    }
+}


### PR DESCRIPTION
Add read/write support to the `FileSystemStat` and `FileSystemStatResult` classes. Should be the latest change to the NFS RPC objects.