### PR TITLE
Expose NFS3 API

### DIFF
--- a/Library/DiscUtils.Nfs/IRpcObject.cs
+++ b/Library/DiscUtils.Nfs/IRpcObject.cs
@@ -1,5 +1,5 @@
-//
-// Copyright (c) 2017, Bianco Veigel
+﻿//
+// Copyright (c) 2017, Quamotion
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -22,29 +22,8 @@
 
 namespace DiscUtils.Nfs
 {
-    internal enum NfsProc3 : uint
+    public interface IRpcObject
     {
-        Null = 0,
-        GetAttr = 1,
-        SetAttr = 2,
-        Lookup = 3,
-        Access = 4,
-        Readlink = 5,
-        Read = 6,
-        Write = 7,
-        Create = 8,
-        Mkdir = 9,
-        Symlink = 10,
-        Mknod = 11,
-        Remove = 12,
-        Rmdir = 13,
-        Rename = 14,
-        Link = 15,
-        ReadDir = 16,
-        ReadDirPlus = 17,
-        Fsstat = 18,
-        Fsinfo = 19,
-        Pathconf = 20,
-        Commit = 21,
+        void Write(XdrDataWriter writer);
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3.cs
+++ b/Library/DiscUtils.Nfs/Nfs3.cs
@@ -228,7 +228,7 @@ namespace DiscUtils.Nfs
                                                  uint maxCount)
         {
             MemoryStream ms = new MemoryStream();
-            XdrDataWriter writer = StartCallMessage(ms, _client.Credentials, NfsProc3.Readdirplus);
+            XdrDataWriter writer = StartCallMessage(ms, _client.Credentials, NfsProc3.ReadDirPlus);
             dir.Write(writer);
             writer.Write(cookie);
             writer.Write(cookieVerifier);

--- a/Library/DiscUtils.Nfs/Nfs3CallResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3CallResult.cs
@@ -27,11 +27,11 @@ namespace DiscUtils.Nfs
     /// <summary>
     /// Base class for all NFS result structures.
     /// </summary>
-    public abstract class Nfs3CallResult
+    public abstract class Nfs3CallResult : IRpcObject
     {
         public Nfs3Status Status { get; set; }
 
-        internal virtual void Write(XdrDataWriter writer)
+        public virtual void Write(XdrDataWriter writer)
         {
             throw new NotSupportedException();
         }

--- a/Library/DiscUtils.Nfs/Nfs3CreateResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3CreateResult.cs
@@ -55,7 +55,7 @@ namespace DiscUtils.Nfs
 
         public Nfs3FileHandle FileHandle { get; set; }
 
-        internal override void Write(XdrDataWriter writer)
+        public override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
 

--- a/Library/DiscUtils.Nfs/Nfs3ExportResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3ExportResult.cs
@@ -42,7 +42,7 @@ namespace DiscUtils.Nfs
 
         public List<Nfs3Export> Exports { get; set; }
 
-        internal override void Write(XdrDataWriter writer)
+        public override void Write(XdrDataWriter writer)
         {
             foreach (var export in Exports)
             {

--- a/Library/DiscUtils.Nfs/Nfs3FileSystemInfoResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileSystemInfoResult.cs
@@ -48,7 +48,7 @@ namespace DiscUtils.Nfs
 
         public Nfs3FileAttributes PostOpAttributes { get; set; }
 
-        internal override void Write(XdrDataWriter writer)
+        public override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
 

--- a/Library/DiscUtils.Nfs/Nfs3FileSystemStatResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileSystemStatResult.cs
@@ -48,7 +48,7 @@ namespace DiscUtils.Nfs
 
         public Nfs3FileSystemStat FileSystemStat { get; set; }
 
-        internal override void Write(XdrDataWriter writer)
+        public override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
 

--- a/Library/DiscUtils.Nfs/Nfs3GetAttributesResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3GetAttributesResult.cs
@@ -38,10 +38,14 @@ namespace DiscUtils.Nfs
 
         public Nfs3FileAttributes Attributes { get; set; }
 
-        internal override void Write(XdrDataWriter writer)
+        public override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
-            Attributes.Write(writer);
+
+            if (Status == Nfs3Status.Ok)
+            {
+                Attributes.Write(writer);
+            }
         }
 
         public override bool Equals(object obj)

--- a/Library/DiscUtils.Nfs/Nfs3LookupResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3LookupResult.cs
@@ -54,7 +54,7 @@ namespace DiscUtils.Nfs
 
         public Nfs3FileHandle ObjectHandle { get; set; }
 
-        internal override void Write(XdrDataWriter writer)
+        public override void Write(XdrDataWriter writer)
         {
             writer.Write((int)this.Status);
 

--- a/Library/DiscUtils.Nfs/Nfs3ModifyResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3ModifyResult.cs
@@ -38,7 +38,7 @@ namespace DiscUtils.Nfs
 
         public Nfs3WeakCacheConsistency CacheConsistency { get; set; }
 
-        internal override void Write(XdrDataWriter writer)
+        public override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
             CacheConsistency.Write(writer);

--- a/Library/DiscUtils.Nfs/Nfs3MountResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3MountResult.cs
@@ -58,7 +58,7 @@ namespace DiscUtils.Nfs
 
         public Nfs3FileHandle FileHandle { get; set; }
 
-        internal override void Write(XdrDataWriter writer)
+        public override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
 

--- a/Library/DiscUtils.Nfs/Nfs3ReadDirPlusResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3ReadDirPlusResult.cs
@@ -65,7 +65,7 @@ namespace DiscUtils.Nfs
 
         public bool Eof { get; set; }
 
-        internal override void Write(XdrDataWriter writer)
+        public override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
 
@@ -86,7 +86,7 @@ namespace DiscUtils.Nfs
                 }
 
                 writer.Write(false);
-                writer.Write(true); // EOF
+                writer.Write(Eof);
             }
         }
 

--- a/Library/DiscUtils.Nfs/Nfs3ReadResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3ReadResult.cs
@@ -57,7 +57,7 @@ namespace DiscUtils.Nfs
 
         public Nfs3FileAttributes FileAttributes { get; set; }
 
-        internal override void Write(XdrDataWriter writer)
+        public override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
 

--- a/Library/DiscUtils.Nfs/Nfs3WriteResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3WriteResult.cs
@@ -53,7 +53,7 @@ namespace DiscUtils.Nfs
 
         public ulong WriteVerifier { get; set; }
 
-        internal override void Write(XdrDataWriter writer)
+        public override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
             CacheConsistency.Write(writer);

--- a/Library/DiscUtils.Nfs/RpcAuthentication.cs
+++ b/Library/DiscUtils.Nfs/RpcAuthentication.cs
@@ -26,7 +26,7 @@ using System.IO;
 
 namespace DiscUtils.Nfs
 {
-    internal class RpcAuthentication
+    public class RpcAuthentication
     {
         private readonly byte[] _body;
         private readonly RpcAuthFlavour _flavour;

--- a/Library/DiscUtils.Nfs/RpcCallHeader.cs
+++ b/Library/DiscUtils.Nfs/RpcCallHeader.cs
@@ -26,7 +26,7 @@ using System.IO;
 
 namespace DiscUtils.Nfs
 {
-    internal class RpcCallHeader
+    public class RpcCallHeader
     {
         public RpcCallHeader()
         {
@@ -37,19 +37,14 @@ namespace DiscUtils.Nfs
             RpcVersion = reader.ReadUInt32();
             Program = reader.ReadUInt32();
             Version = reader.ReadUInt32();
-            Proc = (NfsProc3)reader.ReadUInt32();
+            Proc = reader.ReadInt32();
             Credentials = new RpcAuthentication(reader);
             Verifier = new RpcAuthentication(reader);
-
-            if (!Enum.IsDefined(typeof(NfsProc3), Proc))
-            {
-                throw new InvalidDataException();
-            }
         }
 
         public RpcAuthentication Credentials { get; set; }
 
-        public NfsProc3 Proc { get; set; }
+        public int Proc { get; set; }
 
         public uint Program { get; set; }
 

--- a/Library/DiscUtils.Nfs/RpcMessageHeader.cs
+++ b/Library/DiscUtils.Nfs/RpcMessageHeader.cs
@@ -96,7 +96,7 @@ namespace DiscUtils.Nfs
                     AcceptReply = new RpcAcceptedReplyHeader()
                     {
                         AcceptStatus = RpcAcceptStatus.Success,
-                        Verifier = new RpcAuthentication(new RpcUnixCredential(0, 0))
+                        Verifier = RpcAuthentication.Null()
                     }
                 }
             };

--- a/Library/DiscUtils.Nfs/RpcProgram.cs
+++ b/Library/DiscUtils.Nfs/RpcProgram.cs
@@ -65,10 +65,15 @@ namespace DiscUtils.Nfs
 
         protected XdrDataWriter StartCallMessage(MemoryStream ms, RpcCredentials credentials, MountProc3 procedure)
         {
-            return StartCallMessage(ms, credentials, (NfsProc3)procedure);
+            return StartCallMessage(ms, credentials, (int)procedure);
         }
 
         protected XdrDataWriter StartCallMessage(MemoryStream ms, RpcCredentials credentials, NfsProc3 procedure)
+        {
+            return StartCallMessage(ms, credentials, (int)procedure);
+        }
+
+        protected XdrDataWriter StartCallMessage(MemoryStream ms, RpcCredentials credentials, int procedure)
         {
             XdrDataWriter writer = new XdrDataWriter(ms);
 

--- a/Library/DiscUtils.Nfs/XdrDataReader.cs
+++ b/Library/DiscUtils.Nfs/XdrDataReader.cs
@@ -26,7 +26,7 @@ using DiscUtils.Streams;
 
 namespace DiscUtils.Nfs
 {
-    internal sealed class XdrDataReader : BigEndianDataReader
+    public sealed class XdrDataReader : BigEndianDataReader
     {
         public XdrDataReader(Stream stream)
             : base(stream) {}

--- a/Library/DiscUtils.Nfs/XdrDataWriter.cs
+++ b/Library/DiscUtils.Nfs/XdrDataWriter.cs
@@ -26,7 +26,7 @@ using DiscUtils.Streams;
 
 namespace DiscUtils.Nfs
 {
-    internal sealed class XdrDataWriter : BigEndianDataWriter
+    public sealed class XdrDataWriter : BigEndianDataWriter
     {
         public XdrDataWriter(Stream stream)
             : base(stream) {}

--- a/Tests/LibraryTests/Nfs/RpcCallHeaderTest.cs
+++ b/Tests/LibraryTests/Nfs/RpcCallHeaderTest.cs
@@ -36,7 +36,7 @@ namespace LibraryTests.Nfs
                 Credentials = new RpcAuthentication()
                 {
                 },
-                Proc = NfsProc3.Commit,
+                Proc = (int)NfsProc3.Commit,
                 Program = 5,
                 RpcVersion = 6,
                 Verifier = new RpcAuthentication()


### PR DESCRIPTION
This PR exposes the NFS API so you can reuse it from a 3rd party library. Fits into the discussion whether we should include a NFS server in DiscUtils or not.

- Exposes the `XdrDataReader` and `XdrDataWriter` classes and makes the constructors of the RPC objects public.
- Adds a `IRpcObject` interface to any object which can be serialized to RPC. 
- Fixes the casing of some values of the `NfsProc3` enumeration
- Makes the `Proc` field of `RpcCallHeader` an `int` instead of a value of the `NfsProc3` enumeration. The RPC protocol is program-agnostic and defines Proc as an integer; individual RPC programs can later cast these values.