### PR TITLE
Include the AppVeyor build number in the package version

### DIFF
--- a/Library/DiscUtils.BootConfig/DiscUtils.BootConfig.csproj
+++ b/Library/DiscUtils.BootConfig/DiscUtils.BootConfig.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils BootConfig parser</Description>
     <AssemblyTitle>DiscUtils.BootConfig</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.BootConfig</AssemblyName>

--- a/Library/DiscUtils.Btrfs/DiscUtils.Btrfs.csproj
+++ b/Library/DiscUtils.Btrfs/DiscUtils.Btrfs.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils Btrfs</Description>
     <AssemblyTitle>DiscUtils.Btrfs</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Bianco Veigel</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Btrfs</AssemblyName>

--- a/Library/DiscUtils.Containers/DiscUtils.Containers.csproj
+++ b/Library/DiscUtils.Containers/DiscUtils.Containers.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils, meta-package with container formats such as WIM, DMG, VHD, VHDX, XVA, VMDK</Description>
     <AssemblyTitle>DiscUtils.Containers</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Containers</AssemblyName>

--- a/Library/DiscUtils.Core/DiscUtils.Core.csproj
+++ b/Library/DiscUtils.Core/DiscUtils.Core.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>Implementation of the ISO, UDF, FAT and NTFS file systems is now fairly stable. VHD, XVA, VMDK and VDI disk formats are implemented, as well as read/write Registry support. The library also includes a simple iSCSI initiator, for accessing disks via iSCSI and an NFS client implementation.</Description>
     <AssemblyTitle>DiscUtils (for .NET and .NET Core), core library that supports parts of DiscUtils</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;Quamotion;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Library/DiscUtils.Dmg/DiscUtils.Dmg.csproj
+++ b/Library/DiscUtils.Dmg/DiscUtils.Dmg.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils dmg parser. Works with apple disk (.dmg) files</Description>
     <AssemblyTitle>DiscUtils.Dmg</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Dmg</AssemblyName>

--- a/Library/DiscUtils.Ext/DiscUtils.Ext.csproj
+++ b/Library/DiscUtils.Ext/DiscUtils.Ext.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils ext filesystem parser</Description>
     <AssemblyTitle>DiscUtils.Ext</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Ext</AssemblyName>

--- a/Library/DiscUtils.Fat/DiscUtils.Fat.csproj
+++ b/Library/DiscUtils.Fat/DiscUtils.Fat.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils FAT filesystem parser</Description>
     <AssemblyTitle>DiscUtils.Fat</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Fat</AssemblyName>

--- a/Library/DiscUtils.FileSystems/DiscUtils.FileSystems.csproj
+++ b/Library/DiscUtils.FileSystems/DiscUtils.FileSystems.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils, meta-package with filesystems</Description>
     <AssemblyTitle>DiscUtils.FileSystems</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.FileSystems</AssemblyName>

--- a/Library/DiscUtils.HfsPlus/DiscUtils.HfsPlus.csproj
+++ b/Library/DiscUtils.HfsPlus/DiscUtils.HfsPlus.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils Hfs+ filesystem parser</Description>
     <AssemblyTitle>DiscUtils.HfsPlus</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.HfsPlus</AssemblyName>

--- a/Library/DiscUtils.Iscsi/DiscUtils.Iscsi.csproj
+++ b/Library/DiscUtils.Iscsi/DiscUtils.Iscsi.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils iSCSI</Description>
     <AssemblyTitle>DiscUtils.Iscsi</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Iscsi</AssemblyName>

--- a/Library/DiscUtils.Iso9660/DiscUtils.Iso9660.csproj
+++ b/Library/DiscUtils.Iso9660/DiscUtils.Iso9660.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils Iso9660</Description>
     <AssemblyTitle>DiscUtils.Iso9660</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Iso9660</AssemblyName>

--- a/Library/DiscUtils.Lvm/DiscUtils.Lvm.csproj
+++ b/Library/DiscUtils.Lvm/DiscUtils.Lvm.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils LVM</Description>
     <AssemblyTitle>DiscUtils.Lvm</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Bianco Veigel</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Lvm</AssemblyName>

--- a/Library/DiscUtils.Net/DiscUtils.Net.csproj
+++ b/Library/DiscUtils.Net/DiscUtils.Net.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils NET</Description>
     <AssemblyTitle>DiscUtils.Net</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Net</AssemblyName>

--- a/Library/DiscUtils.Nfs/DiscUtils.Nfs.csproj
+++ b/Library/DiscUtils.Nfs/DiscUtils.Nfs.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils Nfs</Description>
     <AssemblyTitle>DiscUtils.Nfs</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Nfs</AssemblyName>

--- a/Library/DiscUtils.Ntfs/DiscUtils.Ntfs.csproj
+++ b/Library/DiscUtils.Ntfs/DiscUtils.Ntfs.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils NTFS filesystem parser</Description>
     <AssemblyTitle>DiscUtils.Ntfs</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Ntfs</AssemblyName>

--- a/Library/DiscUtils.OpticalDiscSharing/DiscUtils.OpticalDiscSharing.csproj
+++ b/Library/DiscUtils.OpticalDiscSharing/DiscUtils.OpticalDiscSharing.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils OpticalDiscSharing</Description>
     <AssemblyTitle>DiscUtils.OpticalDiscSharing</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.OpticalDiscSharing</AssemblyName>

--- a/Library/DiscUtils.OpticalDisk/DiscUtils.OpticalDisk.csproj
+++ b/Library/DiscUtils.OpticalDisk/DiscUtils.OpticalDisk.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils OpticalDisk</Description>
     <AssemblyTitle>DiscUtils.OpticalDisk</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.OpticalDisk</AssemblyName>

--- a/Library/DiscUtils.Registry/DiscUtils.Registry.csproj
+++ b/Library/DiscUtils.Registry/DiscUtils.Registry.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils Registry</Description>
     <AssemblyTitle>DiscUtils.Registry</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Registry</AssemblyName>

--- a/Library/DiscUtils.Sdi/DiscUtils.Sdi.csproj
+++ b/Library/DiscUtils.Sdi/DiscUtils.Sdi.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils Sdi</Description>
     <AssemblyTitle>DiscUtils.Sdi</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Sdi</AssemblyName>

--- a/Library/DiscUtils.SquashFs/DiscUtils.SquashFs.csproj
+++ b/Library/DiscUtils.SquashFs/DiscUtils.SquashFs.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils SquashFs filesystem parser</Description>
     <AssemblyTitle>DiscUtils.SquashFs</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.SquashFs</AssemblyName>

--- a/Library/DiscUtils.Streams/DiscUtils.Streams.csproj
+++ b/Library/DiscUtils.Streams/DiscUtils.Streams.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils Streams</Description>
     <AssemblyTitle>DiscUtils.Streams</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike;Bianco Veigel</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Streams</AssemblyName>

--- a/Library/DiscUtils.Swap/DiscUtils.Swap.csproj
+++ b/Library/DiscUtils.Swap/DiscUtils.Swap.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils Swap</Description>
     <AssemblyTitle>DiscUtils.Swap</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Bianco Veigel</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Swap</AssemblyName>

--- a/Library/DiscUtils.Transports/DiscUtils.Transports.csproj
+++ b/Library/DiscUtils.Transports/DiscUtils.Transports.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils, meta-package with transports, such as iSCSI and NFS</Description>
     <AssemblyTitle>DiscUtils.Transports</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Transports</AssemblyName>

--- a/Library/DiscUtils.Udf/DiscUtils.Udf.csproj
+++ b/Library/DiscUtils.Udf/DiscUtils.Udf.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils UDF filesystem parser.</Description>
     <AssemblyTitle>DiscUtils.Udf</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Udf</AssemblyName>

--- a/Library/DiscUtils.Vdi/DiscUtils.Vdi.csproj
+++ b/Library/DiscUtils.Vdi/DiscUtils.Vdi.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils Vdi</Description>
     <AssemblyTitle>DiscUtils.Vdi</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Vdi</AssemblyName>

--- a/Library/DiscUtils.Vhd/DiscUtils.Vhd.csproj
+++ b/Library/DiscUtils.Vhd/DiscUtils.Vhd.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils VHD</Description>
     <AssemblyTitle>DiscUtils.Vhd</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Vhd</AssemblyName>

--- a/Library/DiscUtils.Vhdx/DiscUtils.Vhdx.csproj
+++ b/Library/DiscUtils.Vhdx/DiscUtils.Vhdx.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils VHDX</Description>
     <AssemblyTitle>DiscUtils.Vhdx</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Vhdx</AssemblyName>

--- a/Library/DiscUtils.Vmdk/DiscUtils.Vmdk.csproj
+++ b/Library/DiscUtils.Vmdk/DiscUtils.Vmdk.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils VMDK</Description>
     <AssemblyTitle>DiscUtils.Vmdk</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Vmdk</AssemblyName>

--- a/Library/DiscUtils.Wim/DiscUtils.Wim.csproj
+++ b/Library/DiscUtils.Wim/DiscUtils.Wim.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils WIM</Description>
     <AssemblyTitle>DiscUtils.Wim</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Wim</AssemblyName>

--- a/Library/DiscUtils.Xfs/DiscUtils.Xfs.csproj
+++ b/Library/DiscUtils.Xfs/DiscUtils.Xfs.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Description>DiscUtils XFS</Description>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
+    <AssemblyTitle>DiscUtils.Xfs</AssemblyTitle>
     <Authors>Bianco Veigel</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Xfs</AssemblyName>

--- a/Library/DiscUtils.Xfs/DiscUtils.Xfs.csproj
+++ b/Library/DiscUtils.Xfs/DiscUtils.Xfs.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils XFS</Description>
-    <AssemblyTitle>DiscUtils.Xfs</AssemblyTitle>
     <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Bianco Veigel</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>

--- a/Library/DiscUtils.Xva/DiscUtils.Xva.csproj
+++ b/Library/DiscUtils.Xva/DiscUtils.Xva.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <Description>DiscUtils XVA</Description>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
+    <AssemblyTitle>DiscUtils.Xva</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Xva</AssemblyName>

--- a/Library/DiscUtils.Xva/DiscUtils.Xva.csproj
+++ b/Library/DiscUtils.Xva/DiscUtils.Xva.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
 
   <PropertyGroup>
     <Description>DiscUtils XVA</Description>
-    <AssemblyTitle>DiscUtils.Xva</AssemblyTitle>
     <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>

--- a/Library/DiscUtils/DiscUtils.csproj
+++ b/Library/DiscUtils/DiscUtils.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="../common.props" />
+  
   <PropertyGroup>
     <Description>DiscUtils, complete meta-package</Description>
     <AssemblyTitle>DiscUtils</AssemblyTitle>
-    <VersionPrefix>0.13.0-alpha</VersionPrefix>
     <Authors>Kenneth Bell;LordMike</Authors>
     <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils</AssemblyName>

--- a/Library/common.props
+++ b/Library/common.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>0.13.0</VersionPrefix>
+    <VersionSuffix>alpha</VersionSuffix>
+  </PropertyGroup>
+</Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,12 @@ build_script:
 
     Update-AppveyorBuild -Version "$version build $env:APPVEYOR_BUILD_NUMBER"
 - cmd: REM Build
-- cmd: msbuild /t:Build /p:Configuration=Release /p:IncludeSymbols=True /Verbosity:Minimal /p:VersionSuffix=alpha-r%APPVEYOR_BUILD_NUMBER%
+- cmd: msbuild /t:Build /p:Configuration=Release /p:IncludeSymbols=True /Verbosity:Minimal /p:VersionSuffix=alpha%APPVEYOR_BUILD_NUMBER%
 test_script:
 - cmd: cd Tests\LibraryTests\bin\Release\netcoreapp1.1
 - cmd: dotnet test ..\..\..\LibraryTests.csproj -c Release --no-build --logger:trx
 install:
-- msbuild /t:Restore /Verbosity:Minimal /p:VersionSuffix=alpha-r%APPVEYOR_BUILD_NUMBER%
+- msbuild /t:Restore /Verbosity:Minimal /p:VersionSuffix=alpha%APPVEYOR_BUILD_NUMBER%
 artifacts:
 - path: '**\*.nupkg'
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,12 @@ build_script:
 
     Update-AppveyorBuild -Version "$version build $env:APPVEYOR_BUILD_NUMBER"
 - cmd: REM Build
-- cmd: msbuild /t:Build /p:Configuration=Release /p:IncludeSymbols=True /Verbosity:Minimal 
+- cmd: msbuild /t:Build /p:Configuration=Release /p:IncludeSymbols=True /Verbosity:Minimal /p:VersionSuffix=alpha-r%APPVEYOR_BUILD_NUMBER%
 test_script:
 - cmd: cd Tests\LibraryTests\bin\Release\netcoreapp1.1
 - cmd: dotnet test ..\..\..\LibraryTests.csproj -c Release --no-build --logger:trx
 install:
-- msbuild /t:Restore /Verbosity:Minimal
+- msbuild /t:Restore /Verbosity:Minimal /p:VersionSuffix=alpha-r%APPVEYOR_BUILD_NUMBER%
 artifacts:
 - path: '**\*.nupkg'
 deploy:


### PR DESCRIPTION
Currently all NuGet packages which are built during the AppVeyor CI builds have the same version, `0.13-alpha`.

This PR updates the packaging process so that they include the AppVeyor build number.
The `VersionPrefix` and `VersionSuffix` are set in a `common.props` file. The `VersionSuffix` is overriden during the AppVeyor build.

This makes it easier for users (like me 😄) to consume interim versions of DiscUtils, either from the AppVeyor NuGet repository (if enabled) or an internal NuGet package feed.

Using AppVeyor build numbers works; a more structural solution may be to use a packaging like NerdBank.GitVersioning.