### PR TITLE
Add more NFS3 objects

### DIFF
--- a/Library/DiscUtils.Nfs/Nfs3AccessResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3AccessResult.cs
@@ -20,10 +20,16 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+
 namespace DiscUtils.Nfs
 {
     public sealed class Nfs3AccessResult : Nfs3CallResult
     {
+        public Nfs3AccessResult()
+        {
+        }
+
         internal Nfs3AccessResult(XdrDataReader reader)
         {
             Status = (Nfs3Status)reader.ReadInt32();
@@ -38,5 +44,38 @@ namespace DiscUtils.Nfs
         public Nfs3AccessPermissions Access { get; set; }
 
         public Nfs3FileAttributes ObjectAttributes { get; set; }
+
+        public override void Write(XdrDataWriter writer)
+        {
+            writer.Write((int)Status);
+            writer.Write(ObjectAttributes != null);
+            if (ObjectAttributes != null)
+            {
+                ObjectAttributes.Write(writer);
+            }
+            writer.Write((int)Access);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3AccessResult);
+        }
+
+        public bool Equals(Nfs3AccessResult other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Access == Access
+                && object.Equals(other.ObjectAttributes, ObjectAttributes)
+                && other.Status == Status;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Access, ObjectAttributes, Status);
+        }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3GetAttributesResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3GetAttributesResult.cs
@@ -38,7 +38,7 @@ namespace DiscUtils.Nfs
 
         public Nfs3FileAttributes Attributes { get; set; }
 
-        internal override void Write(XdrDataWriter writer)
+        public override void Write(XdrDataWriter writer)
         {
             writer.Write((int)Status);
             Attributes.Write(writer);

--- a/Library/DiscUtils.Nfs/Nfs3PathConfResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3PathConfResult.cs
@@ -1,0 +1,135 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+
+namespace DiscUtils.Nfs
+{
+    public class Nfs3PathConfResult : Nfs3CallResult
+    {
+        public Nfs3PathConfResult()
+        {
+        }
+
+        public Nfs3PathConfResult(XdrDataReader reader)
+        {
+            Status = (Nfs3Status)reader.ReadInt32();
+            ObjectAttributes = new Nfs3FileAttributes(reader);
+
+            if (Status == Nfs3Status.Ok)
+            {
+                LinkMax = reader.ReadUInt32();
+                NameMax = reader.ReadUInt32();
+                NoTrunc = reader.ReadBool();
+                ChownRestricted = reader.ReadBool();
+                CaseInsensitive = reader.ReadBool();
+                CasePreserving = reader.ReadBool();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the attributes of the object specified by object.
+        /// </summary>
+        public Nfs3FileAttributes ObjectAttributes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of hard links to an object.
+        /// </summary>
+        public uint LinkMax { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum length of a component of a filename.
+        /// </summary>
+        public uint NameMax { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the server will reject any request that
+        /// includes a name longer than name_max with the error,
+        /// NFS3ERR_NAMETOOLONG.If FALSE, any length name over
+        /// name_max bytes will be silently truncated to name_max
+        /// bytes.
+        /// </summary>
+        public bool NoTrunc { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether server will reject any request to change
+        /// either the owner or the group associated with a file if
+        /// the caller is not the privileged user. (Uid 0.)
+        /// </summary>
+        public bool ChownRestricted { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the server file system does not distinguish
+        /// case when interpreting filenames.
+        /// </summary>
+        public bool CaseInsensitive { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the server file system will preserve the case
+        /// of a name during a CREATE, MKDIR, MKNOD, SYMLINK,
+        /// RENAME, or LINK operation.
+        /// </summary>
+        public bool CasePreserving { get; set; }
+
+        public override void Write(XdrDataWriter writer)
+        {
+            writer.Write((int)Status);
+            ObjectAttributes.Write(writer);
+
+            if (Status == Nfs3Status.Ok)
+            {
+                writer.Write(LinkMax);
+                writer.Write(NameMax);
+                writer.Write(NoTrunc);
+                writer.Write(ChownRestricted);
+                writer.Write(CaseInsensitive);
+                writer.Write(CasePreserving);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3PathConfResult);
+        }
+
+        public bool Equals(Nfs3PathConfResult other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Status == Status
+                && other.LinkMax == LinkMax
+                && other.NameMax == NameMax
+                && other.NoTrunc == NoTrunc
+                && other.ChownRestricted == ChownRestricted
+                && other.CaseInsensitive == CaseInsensitive
+                && other.CasePreserving == CasePreserving;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Status, LinkMax, NameMax, NoTrunc, ChownRestricted, CaseInsensitive, CasePreserving);
+        }
+    }
+}

--- a/Library/DiscUtils.Nfs/Nfs3ReadDirResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3ReadDirResult.cs
@@ -1,0 +1,119 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Collections.Generic;
+#if !NET20
+using System.Linq;
+#endif
+
+namespace DiscUtils.Nfs
+{
+    public class Nfs3ReadDirResult : Nfs3CallResult
+    {
+        public Nfs3ReadDirResult()
+        {
+        }
+
+        public Nfs3ReadDirResult(XdrDataReader reader)
+        {
+            Status = (Nfs3Status)reader.ReadInt32();
+
+            if (reader.ReadBool())
+            {
+                DirAttributes = new Nfs3FileAttributes(reader);
+            }
+
+            DirEntries = new List<Nfs3DirectoryEntry>();
+            if (Status == Nfs3Status.Ok)
+            {
+                CookieVerifier = reader.ReadUInt64();
+
+                while (reader.ReadBool())
+                {
+                    DirEntries.Add(new Nfs3DirectoryEntry(reader));
+                }
+
+                Eof = reader.ReadBool();
+            }
+        }
+
+        public Nfs3FileAttributes DirAttributes { get; set; }
+
+        public List<Nfs3DirectoryEntry> DirEntries { get; set; }
+
+        public ulong CookieVerifier { get; set; }
+
+        public bool Eof { get; set; }
+
+        public override void Write(XdrDataWriter writer)
+        {
+            writer.Write((int)Status);
+
+            writer.Write(DirAttributes != null);
+            if (DirAttributes != null)
+            {
+                DirAttributes.Write(writer);
+            }
+
+            if (Status == Nfs3Status.Ok)
+            {
+                writer.Write(CookieVerifier);
+
+                foreach (var entry in DirEntries)
+                {
+                    writer.Write(true);
+                    entry.Write(writer);
+                }
+
+                writer.Write(false);
+                writer.Write(Eof);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Nfs3ReadDirResult);
+        }
+
+        public bool Equals(Nfs3ReadDirResult other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Status == Status
+                && object.Equals(other.DirAttributes, DirAttributes)
+                && other.CookieVerifier == CookieVerifier
+#if !NET20
+                && Enumerable.SequenceEqual(other.DirEntries, DirEntries)
+#endif
+                && other.Eof == Eof;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Status, DirAttributes, CookieVerifier, DirEntries, Eof);
+        }
+    }
+}

--- a/Tests/LibraryTests/Nfs/Nfs3AccessResultTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3AccessResultTest.cs
@@ -1,0 +1,63 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using DiscUtils.Nfs;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace LibraryTests.Nfs
+{
+    public class Nfs3AccessResultTest
+    {
+        [Fact]
+        public void RoundTripTest()
+        {
+            Nfs3AccessResult result = new Nfs3AccessResult()
+            {
+                Access = Nfs3AccessPermissions.Execute,
+                ObjectAttributes = new Nfs3FileAttributes()
+                {
+                    AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
+                    ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
+                    ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 3))
+                },
+                Status = Nfs3Status.AccessDenied
+            };
+
+            Nfs3AccessResult clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                result.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new Nfs3AccessResult(reader);
+            }
+
+            Assert.Equal(result, clone);
+        }
+    }
+}

--- a/Tests/LibraryTests/Nfs/Nfs3PathConfResultTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3PathConfResultTest.cs
@@ -1,0 +1,67 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using DiscUtils.Nfs;
+using System;
+using System.IO;
+using Xunit;
+
+namespace LibraryTests.Nfs
+{
+    public class Nfs3PathConfResultTest
+    {
+        [Fact]
+        public void RoundTripTest()
+        {
+            Nfs3PathConfResult authentication = new Nfs3PathConfResult()
+            {
+                Status = Nfs3Status.Ok,
+                CaseInsensitive = true,
+                CasePreserving = true,
+                ChownRestricted = true,
+                LinkMax = 1,
+                NameMax = 2,
+                NoTrunc = true,
+                ObjectAttributes = new Nfs3FileAttributes()
+                {
+                    AccessTime = new Nfs3FileTime(new DateTime(2017, 1, 1)),
+                    ChangeTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
+                    ModifyTime = new Nfs3FileTime(new DateTime(2017, 1, 2)),
+                }
+            };
+
+            Nfs3PathConfResult clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                authentication.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new Nfs3PathConfResult(reader);
+            }
+
+            Assert.Equal(authentication, clone);
+        }
+    }
+}

--- a/Tests/LibraryTests/Nfs/Nfs3ReadDirResultTest.cs
+++ b/Tests/LibraryTests/Nfs/Nfs3ReadDirResultTest.cs
@@ -1,0 +1,83 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using DiscUtils.Nfs;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace LibraryTests.Nfs
+{
+    public class Nfs3ReadDirResultTest
+    {
+        [Fact]
+        public void RoundTripTest()
+        {
+            Nfs3ReadDirResult result = new Nfs3ReadDirResult()
+            {
+                Status = Nfs3Status.Ok,
+                Eof = false,
+                CookieVerifier = 1u,
+                DirAttributes = new Nfs3FileAttributes()
+                {
+                    AccessTime = new Nfs3FileTime(new DateTime(2018, 1, 1)),
+                    ChangeTime = new Nfs3FileTime(new DateTime(2018, 1, 2)),
+                    ModifyTime = new Nfs3FileTime(new DateTime(2018, 1, 3)),
+                },
+                DirEntries = new List<Nfs3DirectoryEntry>()
+                {
+                    new Nfs3DirectoryEntry()
+                    {
+                         Cookie = 2u,
+                         FileAttributes = new Nfs3FileAttributes()
+                         {
+                             AccessTime = new Nfs3FileTime(new DateTime(2018, 2, 1)),
+                             ChangeTime = new Nfs3FileTime(new DateTime(2018, 2, 2)),
+                             ModifyTime = new Nfs3FileTime(new DateTime(2018, 2, 3)),
+                         },
+                         FileHandle = new Nfs3FileHandle()
+                         {
+                             Value = new byte[]{0x20, 0x18 }
+                         },
+                         FileId = 2018,
+                         Name = "test.bin"
+                    }
+                }
+            };
+
+            Nfs3ReadDirResult clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                result.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new Nfs3ReadDirResult(reader);
+            }
+
+            Assert.Equal(result, clone);
+        }
+    }
+}


### PR DESCRIPTION
Adds:
* [`Nfs3PathConfResult`](https://tools.ietf.org/html/rfc1813#page-90) (Procedure 20: PATHCONF - Retrieve POSIX information)
* [`Nfs3ReadDirResult`](https://tools.ietf.org/html/rfc1813#page-75) (Procedure 16: READDIR - Read From Directory)

Makes `Nfs3AccessResult` read/write.