### PR TITLE
Update PortMapper implementation to be consistent with NFS, Mount protocol

### DIFF
--- a/Library/DiscUtils.Nfs/PortMap2.cs
+++ b/Library/DiscUtils.Nfs/PortMap2.cs
@@ -24,12 +24,12 @@ using System.IO;
 
 namespace DiscUtils.Nfs
 {
-    internal sealed class PortMapper : RpcProgram
+    internal sealed class PortMap2 : RpcProgram
     {
         public const int ProgramIdentifier = 100000;
         public const int ProgramVersion = 2;
 
-        public PortMapper(RpcClient client)
+        public PortMap2(RpcClient client)
             : base(client) {}
 
         public override int Identifier
@@ -42,18 +42,23 @@ namespace DiscUtils.Nfs
             get { return ProgramVersion; }
         }
 
-        public int GetPort(int program, int version, PortMapperProtocol protocol)
+        public int GetPort(int program, int version, PortMap2Protocol protocol)
         {
             MemoryStream ms = new MemoryStream();
-            XdrDataWriter writer = StartCallMessage(ms, null, NfsProc3.Lookup);
-            writer.Write(program);
-            writer.Write(version);
-            writer.Write((uint)protocol);
-            writer.Write((uint)0);
+            XdrDataWriter writer = StartCallMessage(ms, null, PortMapProc2.GetPort);
+
+            new PortMap2Mapping()
+            {
+                Program = program,
+                Version = version,
+                Protocol = protocol,
+                Port = 0
+            }.Write(writer);
 
             RpcReply reply = DoSend(ms);
             if (reply.Header.IsSuccess)
             {
+                var port = new PortMap2Port(reply.BodyReader);
                 return (int)reply.BodyReader.ReadUInt32();
             }
             throw new RpcException(reply.Header.ReplyHeader);

--- a/Library/DiscUtils.Nfs/PortMap2Mapping.cs
+++ b/Library/DiscUtils.Nfs/PortMap2Mapping.cs
@@ -1,0 +1,89 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+
+namespace DiscUtils.Nfs
+{
+    /// <summary> 
+    /// A mapping of(program, version, network ID) to address
+    ///
+    /// The network identifier(r_netid):
+    /// This is a string that represents a local identification for a
+    /// network.This is defined by a system administrator based on local
+    /// conventions, and cannot be depended on to have the same value on
+    /// every system.
+    /// </summary>
+    public class PortMap2Mapping
+    {
+        public PortMap2Mapping()
+        {
+        }
+
+        internal PortMap2Mapping(XdrDataReader reader)
+        {
+            Program = reader.ReadInt32();
+            Version = reader.ReadInt32();
+            Protocol = (PortMap2Protocol)reader.ReadUInt32();
+            Port = reader.ReadUInt32();
+        }
+
+        public int Program { get; set; }
+
+        public int Version { get; set; }
+
+        public PortMap2Protocol Protocol { get; set; }
+
+        public uint Port { get; set; }
+
+        internal void Write(XdrDataWriter writer)
+        {
+            writer.Write(Program);
+            writer.Write(Version);
+            writer.Write((uint)Protocol);
+            writer.Write(Port);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as PortMap2Mapping);
+        }
+
+        public bool Equals(PortMap2Mapping other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Program == Program
+                && other.Version == Version
+                && other.Protocol == Protocol
+                && other.Port == Port;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Program, Version, Protocol, Port);
+        }
+    }
+}

--- a/Library/DiscUtils.Nfs/PortMap2Port.cs
+++ b/Library/DiscUtils.Nfs/PortMap2Port.cs
@@ -1,0 +1,65 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+
+namespace DiscUtils.Nfs
+{
+    public class PortMap2Port : IRpcObject
+    {
+        public PortMap2Port()
+        {
+        }
+
+        public PortMap2Port(XdrDataReader reader)
+        {
+            Port = reader.ReadUInt32();
+        }
+
+        public uint Port { get; set; }
+
+        public void Write(XdrDataWriter writer)
+        {
+            writer.Write(Port);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as PortMap2Port);
+        }
+
+        public bool Equals(PortMap2Port other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other.Port == Port;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Port);
+        }
+    }
+}

--- a/Library/DiscUtils.Nfs/PortMap2Protocol.cs
+++ b/Library/DiscUtils.Nfs/PortMap2Protocol.cs
@@ -1,0 +1,30 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Nfs
+{
+    public enum PortMap2Protocol
+    {
+        Tcp = 6,
+        Udp = 17
+    }
+}

--- a/Library/DiscUtils.Nfs/PortMapProc2.cs
+++ b/Library/DiscUtils.Nfs/PortMapProc2.cs
@@ -1,0 +1,33 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Nfs
+{
+    internal enum PortMapProc2
+    {
+        Null = 0,
+        Set = 1,
+        Unset = 2,
+        GetPort = 3,
+        Dump = 4
+    }
+}

--- a/Library/DiscUtils.Nfs/PortMapperProtocol.cs
+++ b/Library/DiscUtils.Nfs/PortMapperProtocol.cs
@@ -1,8 +1,0 @@
-namespace DiscUtils.Nfs
-{
-    internal enum PortMapperProtocol
-    {
-        Tcp = 6,
-        Udp = 17
-    }
-}

--- a/Library/DiscUtils.Nfs/RpcClient.cs
+++ b/Library/DiscUtils.Nfs/RpcClient.cs
@@ -36,7 +36,7 @@ namespace DiscUtils.Nfs
             _serverAddress = address;
             Credentials = credential;
             _nextTransaction = (uint)new Random().Next();
-            _transports[PortMapper.ProgramIdentifier] = new RpcTcpTransport(address, 111);
+            _transports[PortMap2.ProgramIdentifier] = new RpcTcpTransport(address, 111);
         }
 
         public RpcCredentials Credentials { get; }
@@ -64,8 +64,8 @@ namespace DiscUtils.Nfs
             RpcTcpTransport transport;
             if (!_transports.TryGetValue(program, out transport))
             {
-                PortMapper pm = new PortMapper(this);
-                int port = pm.GetPort(program, version, PortMapperProtocol.Tcp);
+                PortMap2 pm = new PortMap2(this);
+                int port = pm.GetPort(program, version, PortMap2Protocol.Tcp);
                 transport = new RpcTcpTransport(_serverAddress, port);
                 _transports[program] = transport;
             }

--- a/Library/DiscUtils.Nfs/RpcProgram.cs
+++ b/Library/DiscUtils.Nfs/RpcProgram.cs
@@ -63,6 +63,11 @@ namespace DiscUtils.Nfs
             return new RpcReply { Header = header, BodyReader = reader };
         }
 
+        protected XdrDataWriter StartCallMessage(MemoryStream ms, RpcCredentials credentials, PortMapProc2 procedure)
+        {
+            return StartCallMessage(ms, credentials, (int)procedure);
+        }
+
         protected XdrDataWriter StartCallMessage(MemoryStream ms, RpcCredentials credentials, MountProc3 procedure)
         {
             return StartCallMessage(ms, credentials, (int)procedure);

--- a/Tests/LibraryTests/Nfs/PortMap2MappingTest.cs
+++ b/Tests/LibraryTests/Nfs/PortMap2MappingTest.cs
@@ -1,0 +1,57 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using DiscUtils.Nfs;
+using System.IO;
+using Xunit;
+
+namespace LibraryTests.Nfs
+{
+    public class PortMap2MappingTest
+    {
+        [Fact]
+        public void RoundTripTest()
+        {
+            PortMap2Mapping attributes = new PortMap2Mapping()
+            {
+                Port = 1,
+                Program = 2,
+                Protocol = PortMap2Protocol.Tcp,
+                Version = 4
+            };
+
+            PortMap2Mapping clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                attributes.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new PortMap2Mapping(reader);
+            }
+
+            Assert.Equal(attributes, clone);
+        }
+    }
+}

--- a/Tests/LibraryTests/Nfs/PortMap2PortTest.cs
+++ b/Tests/LibraryTests/Nfs/PortMap2PortTest.cs
@@ -1,0 +1,55 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+
+using DiscUtils.Nfs;
+using System.IO;
+using Xunit;
+
+namespace LibraryTests.Nfs
+{
+    public class PortMap2PortTest
+    {
+        [Fact]
+        public void RoundTripTest()
+        {
+            PortMap2Port port = new PortMap2Port()
+            {
+                Port = 2
+            };
+
+            PortMap2Port clone = null;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                port.Write(writer);
+
+                stream.Position = 0;
+                XdrDataReader reader = new XdrDataReader(stream);
+                clone = new PortMap2Port(reader);
+            }
+
+            Assert.Equal(port, clone);
+        }
+    }
+}


### PR DESCRIPTION
The NFS client includes an implementation of the [RPC: Remote Procedure Call Protocol Version 2 (RFC5531)](https://tools.ietf.org/html/rfc5531) protocol and protocols that use the RPC protocol for communications:
- The [NFS Version 3 Protocol (RFC5531)](https://tools.ietf.org/html/rfc1813)
- The [Mount protocol (RFC5531, Appendix 1)](https://tools.ietf.org/html/rfc1813#page-106)
- The [Port Mapper protocol](http://pubs.opengroup.org/onlinepubs/9629799/chap6.htm)

For the NFS and Mount protocol, a specific naming convention was used:
- {Protocol}Proc{Version} is an enum which specifies the different procedures
- {Protocol}{Version}{Object} for the RPC objects
- {Protocol}{Version} for the clients

This PR updates the PortMapper client to use the same naming conventions, and makes some of the objects more explicit.

This gives us a cleaner code base, and makes it easier to implement a server implementation of the protocol.