### PR TITLE
Add missing Nfs3CommitResult, Nfs3CreateMode types

### DIFF
--- a/Library/DiscUtils.Nfs/Nfs3AccessPermissions.cs
+++ b/Library/DiscUtils.Nfs/Nfs3AccessPermissions.cs
@@ -33,6 +33,7 @@ namespace DiscUtils.Nfs
         Modify = 0x04,
         Extend = 0x08,
         Delete = 0x10,
-        Execute = 0x20
+        Execute = 0x20,
+        All = Read | Lookup | Modify | Extend | Delete | Execute
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3CommitResult.cs
+++ b/Library/DiscUtils.Nfs/Nfs3CommitResult.cs
@@ -1,5 +1,5 @@
-//
-// Copyright (c) 2008-2011, Kenneth Bell
+﻿//
+// Copyright (c) 2017, Quamotion
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -20,30 +20,26 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using System;
-using System.IO;
-
 namespace DiscUtils.Nfs
 {
-    /// <summary>
-    /// Base class for all NFS result structures.
-    /// </summary>
-    public abstract class Nfs3CallResult : IRpcObject
+    public class Nfs3CommitResult : Nfs3CallResult
     {
-        public Nfs3Status Status { get; set; }
-
-        public virtual void Write(XdrDataWriter writer)
+        public Nfs3CommitResult()
         {
-            throw new NotSupportedException();
         }
 
-        public virtual long GetSize()
+        public Nfs3WeakCacheConsistency CacheConsistency { get; set; }
+
+        public ulong WriteVerifier { get; set; }
+
+        public override void Write(XdrDataWriter writer)
         {
-            using (MemoryStream stream = new MemoryStream())
+            writer.Write((int)Status);
+            CacheConsistency.Write(writer);
+
+            if (Status == Nfs3Status.Ok)
             {
-                XdrDataWriter writer = new XdrDataWriter(stream);
-                Write(writer);
-                return stream.Length;
+                writer.Write(WriteVerifier);
             }
         }
     }

--- a/Library/DiscUtils.Nfs/Nfs3CreateMode.cs
+++ b/Library/DiscUtils.Nfs/Nfs3CreateMode.cs
@@ -1,0 +1,55 @@
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+namespace DiscUtils.Nfs
+{
+    public enum Nfs3CreateMode
+    {
+        /// <summary>
+        /// UNCHECKED
+        /// means that the file should be created without checking
+        /// for the existence of a duplicate file in the same
+        /// directory. In this case, how.obj_attributes is a sattr3
+        /// describing the initial attributes for the file.
+        /// </summary>
+        Unchecked = 0,
+
+        /// <summary>
+        /// GUARDED
+        /// specifies that the server should check for the presence
+        /// of a duplicate file before performing the create and
+        /// should fail the request with NFS3ERR_EXIST if a
+        /// duplicate file exists. If the file does not exist, the
+        /// request is performed as described for UNCHECKED.
+        /// </summary>
+        Guarded = 1,
+
+        /// <summary>
+        /// EXCLUSIVE specifies that the server is to follow
+        /// exclusive creation semantics, using the verifier to
+        /// ensure exclusive creation of the target. No attributes
+        /// may be provided in this case, since the server may use
+        /// the target file metadata to store the createverf3
+        /// verifier.
+        /// </summary>
+        Exclusive = 2
+    }
+}

--- a/Library/DiscUtils.Nfs/Nfs3DirectoryEntry.cs
+++ b/Library/DiscUtils.Nfs/Nfs3DirectoryEntry.cs
@@ -21,6 +21,7 @@
 //
 
 using System;
+using System.IO;
 
 namespace DiscUtils.Nfs
 {
@@ -97,6 +98,21 @@ namespace DiscUtils.Nfs
         public override int GetHashCode()
         {
             return HashCode.Combine(Cookie, FileAttributes, FileHandle, FileId, Name);
+        }
+
+        public override string ToString()
+        {
+            return this.Name;
+        }
+
+        public long GetSize()
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                XdrDataWriter writer = new XdrDataWriter(stream);
+                Write(writer);
+                return stream.Length;
+            }
         }
     }
 }

--- a/Library/DiscUtils.Nfs/Nfs3FileHandle.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileHandle.cs
@@ -117,5 +117,19 @@ namespace DiscUtils.Nfs
         {
             writer.WriteBuffer(Value);
         }
+
+        public override string ToString()
+        {
+            int value = 0;
+            if (Value != null)
+            {
+                for (int i = Value.Length - 1; i >= 0; i--)
+                {
+                    value = (value << sizeof(byte)) | Value[i];
+                }
+            }
+
+            return value.ToString();
+        }
     }
 }


### PR DESCRIPTION
* Add missing Nfs3CommitResult, Nfs3CreateMode types
* Support determining the size of Nfs3CallResult objects. In some cases, the NFS protocol describes the maximum length of some messages. You can use `GetSize` to determine the current size and decide whether the message can be sent or not.
* Override ToString on some elements for easier debugging