### PR TITLE
Mark RPC-related classes as public 

### DIFF
--- a/Library/DiscUtils.Nfs/MountProc3.cs
+++ b/Library/DiscUtils.Nfs/MountProc3.cs
@@ -1,12 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿//
+// Copyright (c) 2017, Quamotion
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
 
 namespace DiscUtils.Nfs
 {
     // For more information, see
     // https://www.ietf.org/rfc/rfc1813.txt Appendix I: Mount Protocol
-    internal enum MountProc3 : uint
+    public enum MountProc3 : uint
     {
         // Null - Do nothing
         Null = 0,

--- a/Library/DiscUtils.Nfs/Nfs3.cs
+++ b/Library/DiscUtils.Nfs/Nfs3.cs
@@ -26,8 +26,8 @@ namespace DiscUtils.Nfs
 {
     internal sealed class Nfs3 : RpcProgram
     {
-        public const int ProgramIdentifier = 100003;
-        public const int ProgramVersion = 3;
+        public const int ProgramIdentifier = RpcIdentifiers.Nfs3ProgramIdentifier;
+        public const int ProgramVersion = RpcIdentifiers.Nfs3ProgramVersion;
 
         public const int MaxFileHandleSize = 64;
         public const int CookieVerifierSize = 8;

--- a/Library/DiscUtils.Nfs/Nfs3FileHandle.cs
+++ b/Library/DiscUtils.Nfs/Nfs3FileHandle.cs
@@ -30,7 +30,7 @@ namespace DiscUtils.Nfs
         {
         }
 
-        internal Nfs3FileHandle(XdrDataReader reader)
+        public Nfs3FileHandle(XdrDataReader reader)
         {
             Value = reader.ReadBuffer(Nfs3Mount.MaxFileHandleSize);
         }

--- a/Library/DiscUtils.Nfs/Nfs3Mount.cs
+++ b/Library/DiscUtils.Nfs/Nfs3Mount.cs
@@ -29,8 +29,8 @@ namespace DiscUtils.Nfs
     // https://www.ietf.org/rfc/rfc1813.txt Appendix I: Mount Protocol
     internal sealed class Nfs3Mount : RpcProgram
     {
-        public const int ProgramIdentifier = 100005;
-        public const int ProgramVersion = 3;
+        public const int ProgramIdentifier = RpcIdentifiers.Nfs3MountProgramIdentifier;
+        public const int ProgramVersion = RpcIdentifiers.Nfs3MountProgramVersion;
 
         public const int MaxPathLength = 1024;
         public const int MaxNameLength = 255;

--- a/Library/DiscUtils.Nfs/Nfs3SetAttributes.cs
+++ b/Library/DiscUtils.Nfs/Nfs3SetAttributes.cs
@@ -30,7 +30,7 @@ namespace DiscUtils.Nfs
         {
         }
 
-        internal Nfs3SetAttributes(XdrDataReader reader)
+        public Nfs3SetAttributes(XdrDataReader reader)
         {
             SetMode = reader.ReadBool();
 

--- a/Library/DiscUtils.Nfs/NfsProc3.cs
+++ b/Library/DiscUtils.Nfs/NfsProc3.cs
@@ -22,7 +22,7 @@
 
 namespace DiscUtils.Nfs
 {
-    internal enum NfsProc3 : uint
+    public enum NfsProc3 : uint
     {
         Null = 0,
         GetAttr = 1,

--- a/Library/DiscUtils.Nfs/PortMapProc2.cs
+++ b/Library/DiscUtils.Nfs/PortMapProc2.cs
@@ -22,7 +22,7 @@
 
 namespace DiscUtils.Nfs
 {
-    internal enum PortMapProc2
+    public enum PortMapProc2
     {
         Null = 0,
         Set = 1,

--- a/Library/DiscUtils.Nfs/RpcAcceptStatus.cs
+++ b/Library/DiscUtils.Nfs/RpcAcceptStatus.cs
@@ -1,6 +1,28 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
 namespace DiscUtils.Nfs
 {
-    internal enum RpcAcceptStatus
+    public enum RpcAcceptStatus
     {
         Success = 0,
         ProgramUnavailable = 1,

--- a/Library/DiscUtils.Nfs/RpcAcceptedReplyHeader.cs
+++ b/Library/DiscUtils.Nfs/RpcAcceptedReplyHeader.cs
@@ -25,7 +25,7 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal class RpcAcceptedReplyHeader
+    public class RpcAcceptedReplyHeader
     {
         public RpcAcceptStatus AcceptStatus;
         public RpcMismatchInfo MismatchInfo;

--- a/Library/DiscUtils.Nfs/RpcAuthenticationStatus.cs
+++ b/Library/DiscUtils.Nfs/RpcAuthenticationStatus.cs
@@ -1,6 +1,28 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
 namespace DiscUtils.Nfs
 {
-    internal enum RpcAuthenticationStatus
+    public enum RpcAuthenticationStatus
     {
         None = 0,
         BadCredentials = 1,

--- a/Library/DiscUtils.Nfs/RpcIdentifiers.cs
+++ b/Library/DiscUtils.Nfs/RpcIdentifiers.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2008-2011, Kenneth Bell
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -22,9 +22,12 @@
 
 namespace DiscUtils.Nfs
 {
-    public enum RpcMessageType
+    public static class RpcIdentifiers
     {
-        Call = 0,
-        Reply = 1
+        public const int Nfs3ProgramIdentifier = 100003;
+        public const int Nfs3ProgramVersion = 3;
+        public const int Nfs3MountProgramIdentifier = 100005;
+        public const int Nfs3MountProgramVersion = 3;
+        public const int RpcVersion = 2;
     }
 }

--- a/Library/DiscUtils.Nfs/RpcMessageHeader.cs
+++ b/Library/DiscUtils.Nfs/RpcMessageHeader.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal class RpcMessageHeader
+    public class RpcMessageHeader
     {
         public RpcMessageHeader()
         {

--- a/Library/DiscUtils.Nfs/RpcMismatchInfo.cs
+++ b/Library/DiscUtils.Nfs/RpcMismatchInfo.cs
@@ -25,7 +25,7 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal class RpcMismatchInfo
+    public class RpcMismatchInfo
     {
         public uint High;
         public uint Low;

--- a/Library/DiscUtils.Nfs/RpcRejectedReplyHeader.cs
+++ b/Library/DiscUtils.Nfs/RpcRejectedReplyHeader.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal class RpcRejectedReplyHeader
+    public class RpcRejectedReplyHeader
     {
         public RpcAuthenticationStatus AuthenticationStatus;
         public RpcMismatchInfo MismatchInfo;

--- a/Library/DiscUtils.Nfs/RpcRejectedStatus.cs
+++ b/Library/DiscUtils.Nfs/RpcRejectedStatus.cs
@@ -1,6 +1,28 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
 namespace DiscUtils.Nfs
 {
-    internal enum RpcRejectedStatus
+    public enum RpcRejectedStatus
     {
         RpcMismatch = 0,
         AuthError = 1

--- a/Library/DiscUtils.Nfs/RpcReplyHeader.cs
+++ b/Library/DiscUtils.Nfs/RpcReplyHeader.cs
@@ -24,7 +24,7 @@ using System;
 
 namespace DiscUtils.Nfs
 {
-    internal class RpcReplyHeader
+    public class RpcReplyHeader
     {
         public RpcAcceptedReplyHeader AcceptReply;
         public RpcRejectedReplyHeader RejectedReply;

--- a/Library/DiscUtils.Nfs/RpcReplyStatus.cs
+++ b/Library/DiscUtils.Nfs/RpcReplyStatus.cs
@@ -1,6 +1,28 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
 namespace DiscUtils.Nfs
 {
-    internal enum RpcReplyStatus
+    public enum RpcReplyStatus
     {
         Accepted = 0,
         Denied = 1


### PR DESCRIPTION
* Mark RPC-related classes as public so we can implement an RPC server in `DiscUtils.Nfs.Server`.
* Add missing file headers
* Centralize all RPC identifiers in RpcIdentifiers