### PR TITLE
VMDK: Add initial support to SeSparse and VsanSparse disks

### DIFF
--- a/Library/DiscUtils.Vmdk/DescriptorFile.cs
+++ b/Library/DiscUtils.Vmdk/DescriptorFile.cs
@@ -272,6 +272,10 @@ namespace DiscUtils.Vmdk
                     return DiskCreateType.VmfsPassthroughRawDeviceMap;
                 case "streamOptimized":
                     return DiskCreateType.StreamOptimized;
+                case "seSparse":
+                    return DiskCreateType.SeSparse;
+                case "vsanSparse":
+                    return DiskCreateType.VsanSparse;
                 default:
                     throw new ArgumentException(
                         string.Format(CultureInfo.InvariantCulture, "Unknown type: {0}", value), nameof(value));
@@ -306,6 +310,10 @@ namespace DiscUtils.Vmdk
                     return "vmfsPassthroughRawDeviceMap";
                 case DiskCreateType.StreamOptimized:
                     return "streamOptimized";
+                case DiskCreateType.SeSparse:
+                    return "seSparse";
+                case DiskCreateType.VsanSparse:
+                    return "vsanSparse";
                 default:
                     throw new ArgumentException(
                         string.Format(CultureInfo.InvariantCulture, "Unknown type: {0}", value), nameof(value));

--- a/Library/DiscUtils.Vmdk/DiskCreateType.cs
+++ b/Library/DiscUtils.Vmdk/DiskCreateType.cs
@@ -90,6 +90,16 @@ namespace DiscUtils.Vmdk
         /// <summary>
         /// A streaming-optimized disk.
         /// </summary>
-        StreamOptimized = 12
+        StreamOptimized = 12,
+
+        /// <summary>
+        /// ESX SeSparse disk.
+        /// </summary>
+        SeSparse = 13,
+
+        /// <summary>
+        /// ESX VsanSparse disk.
+        /// </summary>
+        VsanSparse = 14
     }
 }

--- a/Library/DiscUtils.Vmdk/DiskImageFile.cs
+++ b/Library/DiscUtils.Vmdk/DiskImageFile.cs
@@ -871,7 +871,7 @@ namespace DiscUtils.Vmdk
             }
             else
             {
-                throw new NotImplementedException("Extent type not implemented");
+                throw new NotImplementedException($"Extent type '{ExtentDescriptor.FormatExtentType(type)}' not implemented");
             }
         }
 
@@ -912,6 +912,12 @@ namespace DiscUtils.Vmdk
 
                 case DiskCreateType.VmfsSparse:
                     return ExtentType.VmfsSparse;
+
+                case DiskCreateType.SeSparse:
+                    return ExtentType.SeSparse;
+
+                case DiskCreateType.VsanSparse:
+                    return ExtentType.VsanSparse;
 
                 default:
                     throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unable to convert {0}",
@@ -977,7 +983,7 @@ namespace DiscUtils.Vmdk
                         ownsParent);
 
                 default:
-                    throw new NotSupportedException();
+                    throw new NotSupportedException($"Extent type '{ExtentDescriptor.FormatExtentType(extent.Type)}' not supported");
             }
         }
 

--- a/Library/DiscUtils.Vmdk/ExtentDescriptor.cs
+++ b/Library/DiscUtils.Vmdk/ExtentDescriptor.cs
@@ -135,6 +135,14 @@ namespace DiscUtils.Vmdk
             {
                 return ExtentType.VmfsRaw;
             }
+            if (type == "SESPARSE")
+            {
+                return ExtentType.SeSparse;
+            }
+            if (type == "VSANSPARSE")
+            {
+                return ExtentType.VsanSparse;
+            }
             throw new ArgumentException("Unknown extent type", nameof(type));
         }
 
@@ -156,6 +164,10 @@ namespace DiscUtils.Vmdk
                     return "VMFSRDM";
                 case ExtentType.VmfsRaw:
                     return "VMFSRAW";
+                case ExtentType.SeSparse:
+                    return "SESPARSE";
+                case ExtentType.VsanSparse:
+                    return "VSANSPARSE";
                 default:
                     throw new ArgumentException("Unknown extent type", nameof(type));
             }

--- a/Library/DiscUtils.Vmdk/ExtentType.cs
+++ b/Library/DiscUtils.Vmdk/ExtentType.cs
@@ -8,6 +8,8 @@ namespace DiscUtils.Vmdk
         Vmfs = 3,
         VmfsSparse = 4,
         VmfsRdm = 5,
-        VmfsRaw = 6
+        VmfsRaw = 6,
+        SeSparse = 7,
+        VsanSparse = 8
     }
 }


### PR DESCRIPTION
This pull request add the initial support to the VMDK SeSparse and VsanSparse disk types.

The initial support only allows to open the disk (`VirtualDisk.OpenDisk`) and read the various values there (like `Capacity`, `Geometry`,...)

Every further operation which involves reading the actual data from the underlying stream will fail with the  exception message (ex: `Extent type 'SESPARSE' not supported`)

Creating disk (`Disk.Initialize`) for these 2 new types will fail with the exception message `Creating disks of this type is not supported`