### PR TITLE
Support reading FAT long file names (VFAT)

### DIFF
--- a/Library/DiscUtils.Fat/DirectoryEntry.cs
+++ b/Library/DiscUtils.Fat/DirectoryEntry.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.IO;
+using System.Text;
 using DiscUtils.Streams;
 
 namespace DiscUtils.Fat
@@ -46,7 +47,7 @@ namespace DiscUtils.Fat
             _options = options;
             _fatVariant = fatVariant;
             byte[] buffer = StreamUtilities.ReadExact(stream, 32);
-            Load(buffer, 0);
+            Load(buffer, 0, options.FileNameEncoding);
         }
 
         internal DirectoryEntry(FatFileSystemOptions options, FileName name, FatAttributes attrs, FatType fatVariant)
@@ -192,9 +193,9 @@ namespace DiscUtils.Fat
             tenths = (byte)(value.Second % 2 * 100 + value.Millisecond / 10);
         }
 
-        private void Load(byte[] data, int offset)
+        private void Load(byte[] data, int offset, Encoding encoding)
         {
-            Name = new FileName(data, offset);
+            Name = new FileName(data, offset, encoding);
             _attr = data[offset + 11];
             _creationTimeTenth = data[offset + 13];
             _creationTime = EndianUtilities.ToUInt16LittleEndian(data, offset + 14);

--- a/Library/DiscUtils.Fat/FatFileSystem.cs
+++ b/Library/DiscUtils.Fat/FatFileSystem.cs
@@ -834,7 +834,7 @@ namespace DiscUtils.Fat
                 FileName name;
                 try
                 {
-                    name = new FileName(pathElements[i], FatOptions.FileNameEncoding);
+                    name = new FileName(pathElements[i], FatOptions.FileNameEncoding, false);
                 }
                 catch (ArgumentException ae)
                 {
@@ -1597,7 +1597,7 @@ namespace DiscUtils.Fat
                 parent = null;
                 return 0;
             }
-            entryId = dir.FindEntry(new FileName(pathEntries[pathOffset], FatOptions.FileNameEncoding));
+            entryId = dir.FindEntry(new FileName(pathEntries[pathOffset], FatOptions.FileNameEncoding, true));
             if (entryId >= 0)
             {
                 if (pathOffset == pathEntries.Length - 1)

--- a/Library/DiscUtils.Fat/Slot.cs
+++ b/Library/DiscUtils.Fat/Slot.cs
@@ -1,0 +1,76 @@
+﻿//
+// Copyright (c) 2018, DiscUtils
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.IO;
+using System.Text;
+using DiscUtils.Streams;
+
+namespace DiscUtils.Fat
+{
+    // More information here: https://www.kernel.org/doc/Documentation/filesystems/vfat.txt
+    internal class Slot
+    {
+        internal Slot(Stream stream)
+        {
+            byte[] buffer = StreamUtilities.ReadExact(stream, 32);
+            Load(buffer, 0);
+        }
+
+        internal string Name { get; private set; }
+
+        internal byte AliasChecksum { get; private set; }
+
+        private void Load(byte[] data, int offset)
+        {
+            byte[] buffer = new byte[12];
+            Array.Copy(data, offset + 1, buffer, 0, 10);
+            Name = Encoding.Unicode.GetString(buffer, 0, 10);
+
+            var attr = (FatAttributes)data[offset + 11];
+            if (attr != (FatAttributes.ReadOnly | FatAttributes.Hidden | FatAttributes.System | FatAttributes.VolumeId))
+                throw new Exception($"Invalid value '{attr}' for attribute byte");
+
+            var reserved = data[offset + 12];
+            if (reserved != 0)
+                throw new Exception($"Reserved byte value '{reserved}' should always be 0");
+
+            AliasChecksum = data[offset + 13];
+
+            Array.Copy(data, offset + 14, buffer, 0, 12);
+            Name += Encoding.Unicode.GetString(buffer);
+
+            var startingCluster = EndianUtilities.ToUInt16LittleEndian(data, offset + 26);
+            if (startingCluster != 0)
+                throw new Exception($"Starting cluster value {startingCluster} should always be 0");
+
+            Array.Copy(data, offset + 28, buffer, 0, 4);
+            Name += Encoding.Unicode.GetString(buffer, 0, 4);
+
+            // StringComparison.Ordinal to force IndexOf to not ignore the null character
+            // ref: https://github.com/dotnet/coreclr/issues/14066
+            var index = Name.IndexOf("\0", StringComparison.Ordinal);
+            if (index > -1)
+                Name = Name.Substring(0, index);
+        }
+    }
+}


### PR DESCRIPTION
As mentioned in #71, here is the implementation to support reading the long file names in the FAT partition.

I manually tested all the possible use cases that came to my mind, and everything works fine.

About handling the writing of LFN, the current FAT project already have the [_fatVariant](https://github.com/DiscUtils/DiscUtils/blob/3c96b22d2d70beeb5e8a61140c66098e0f60cecf/Library/DiscUtils.Fat/DirectoryEntry.cs#L31) which handles the differences between FAT12/FAT16/FAT32. 
By default `FatFileSystem.FormatPartition` creates a `FAT16` variant (see [here](https://github.com/DiscUtils/DiscUtils/blob/3c96b22d2d70beeb5e8a61140c66098e0f60cecf/Library/DiscUtils.Fat/FatFileSystem.cs#L1823)). And he only variant not supporting the LFN it's the FAT8.

So IMHO it's not really necessary to have a separate project to handle the writing of the VFAT, but should be the currect project to be extended further.

Let me know what you think about it.