### PR TITLE
Ext4 Fix BlockGroup64 descriptor size to use superblock value

### DIFF
--- a/Library/DiscUtils.Ext/BlockGroup.cs
+++ b/Library/DiscUtils.Ext/BlockGroup.cs
@@ -27,7 +27,7 @@ namespace DiscUtils.Ext
 {
     internal class BlockGroup64 : BlockGroup
     {
-        public const int DescriptorSize64 = 64;
+        private int _descriptorSize;
 
         public uint BlockBitmapBlockHigh;
         public uint InodeBitmapBlockHigh;
@@ -36,7 +36,12 @@ namespace DiscUtils.Ext
         public ushort FreeInodesCountHigh;
         public ushort UsedDirsCountHigh;
 
-        public override int Size { get { return DescriptorSize64; } }
+        public BlockGroup64(int descriptorSize)
+        {
+            this._descriptorSize = descriptorSize;
+        }
+
+        public override int Size { get { return this._descriptorSize; } }
 
         public override int ReadFrom(byte[] buffer, int offset)
         {
@@ -49,7 +54,7 @@ namespace DiscUtils.Ext
             FreeInodesCountHigh = EndianUtilities.ToUInt16LittleEndian(buffer, offset + 0x2E);
             UsedDirsCountHigh = EndianUtilities.ToUInt16LittleEndian(buffer, offset + 0x30);
 
-            return DescriptorSize64;
+            return this._descriptorSize;
         }
     }
 

--- a/Library/DiscUtils.Ext/SuperBlock.cs
+++ b/Library/DiscUtils.Ext/SuperBlock.cs
@@ -105,7 +105,7 @@ namespace DiscUtils.Ext
             get
             {
                 return (IncompatibleFeatures & IncompatibleFeatures.SixtyFourBit) ==
-                       IncompatibleFeatures.SixtyFourBit && DescriptorSize == 8;
+                       IncompatibleFeatures.SixtyFourBit && DescriptorSize >= 64;
             }
         }
 

--- a/Library/DiscUtils.Ext/VfsExtFileSystem.cs
+++ b/Library/DiscUtils.Ext/VfsExtFileSystem.cs
@@ -73,13 +73,13 @@ namespace DiscUtils.Ext
             long blockDescStart = (superblock.FirstDataBlock + 1) * (long)superblock.BlockSize;
 
             stream.Position = blockDescStart;
-            var bgDescSize = superblock.Has64Bit ? BlockGroup64.DescriptorSize64 : BlockGroup.DescriptorSize;
+            var bgDescSize = superblock.Has64Bit ? superblock.DescriptorSize : BlockGroup.DescriptorSize;
             byte[] blockDescData = StreamUtilities.ReadExact(stream, (int)numGroups * bgDescSize);
 
             _blockGroups = new BlockGroup[numGroups];
             for (int i = 0; i < numGroups; ++i)
             {
-                BlockGroup bg = superblock.Has64Bit ? new BlockGroup64() : new BlockGroup();
+                BlockGroup bg = superblock.Has64Bit ? new BlockGroup64(bgDescSize) : new BlockGroup();
                 bg.ReadFrom(blockDescData, i * bgDescSize);
                 _blockGroups[i] = bg;
             }


### PR DESCRIPTION
To fix this issue: https://github.com/DiscUtils/DiscUtils/issues/130


