### PR TITLE
Support .NET Standard 2.0

### DIFF
--- a/Library/DiscUtils.BootConfig/DiscUtils.BootConfig.csproj
+++ b/Library/DiscUtils.BootConfig/DiscUtils.BootConfig.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils BootConfig parser</Description>
     <AssemblyTitle>DiscUtils.BootConfig</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.BootConfig</AssemblyName>
     <AssemblyOriginatorKeyFile>../../SigningKey.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/Library/DiscUtils.BootConfig/DiscUtils.BootConfig.csproj
+++ b/Library/DiscUtils.BootConfig/DiscUtils.BootConfig.csproj
@@ -24,26 +24,4 @@
     <ProjectReference Include="..\DiscUtils.Registry\DiscUtils.Registry.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <DefineConstants>$(DefineConstants);NET20</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
 </Project>

--- a/Library/DiscUtils.Btrfs/DiscUtils.Btrfs.csproj
+++ b/Library/DiscUtils.Btrfs/DiscUtils.Btrfs.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils Btrfs</Description>
     <AssemblyTitle>DiscUtils.Btrfs</AssemblyTitle>
     <Authors>Bianco Veigel</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Btrfs</AssemblyName>
     <PackageId>DiscUtils.Btrfs</PackageId>
     <PackageTags>DiscUtils;Btrfs</PackageTags>
@@ -18,23 +17,6 @@
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
     <ProjectReference Include="..\DiscUtils.Streams\DiscUtils.Streams.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Containers/DiscUtils.Containers.csproj
+++ b/Library/DiscUtils.Containers/DiscUtils.Containers.csproj
@@ -22,7 +22,7 @@
     <ProjectReference Include="..\DiscUtils.Xva\DiscUtils.Xva.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.5'">
     <ProjectReference Include="..\DiscUtils.OpticalDiscSharing\DiscUtils.OpticalDiscSharing.csproj" />
   </ItemGroup>
 

--- a/Library/DiscUtils.Containers/DiscUtils.Containers.csproj
+++ b/Library/DiscUtils.Containers/DiscUtils.Containers.csproj
@@ -2,7 +2,6 @@
   <Import Project="../common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net20;net40;net45</TargetFrameworks>
     <Description>DiscUtils, meta-package with container formats such as WIM, DMG, VHD, VHDX, XVA, VMDK</Description>
     <AssemblyTitle>DiscUtils.Containers</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>

--- a/Library/DiscUtils.Containers/DiscUtils.Containers.csproj
+++ b/Library/DiscUtils.Containers/DiscUtils.Containers.csproj
@@ -2,10 +2,10 @@
   <Import Project="../common.props" />
 
   <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net20;net40;net45</TargetFrameworks>
     <Description>DiscUtils, meta-package with container formats such as WIM, DMG, VHD, VHDX, XVA, VMDK</Description>
     <AssemblyTitle>DiscUtils.Containers</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Containers</AssemblyName>
     <PackageId>DiscUtils.Containers</PackageId>
     <PackageTags>DiscUtils;VHD;VHDX;XVA;VMDK;DMG</PackageTags>
@@ -22,21 +22,8 @@
     <ProjectReference Include="..\DiscUtils.Xva\DiscUtils.Xva.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
+  <ItemGroup>
     <ProjectReference Include="..\DiscUtils.OpticalDiscSharing\DiscUtils.OpticalDiscSharing.csproj" />
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <ProjectReference Include="..\DiscUtils.OpticalDiscSharing\DiscUtils.OpticalDiscSharing.csproj" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <ProjectReference Include="..\DiscUtils.OpticalDiscSharing\DiscUtils.OpticalDiscSharing.csproj" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Core/CoreCompat/ReflectionHelper.cs
+++ b/Library/DiscUtils.Core/CoreCompat/ReflectionHelper.cs
@@ -9,7 +9,7 @@ namespace DiscUtils.CoreCompat
     {
         public static bool IsEnum(Type type)
         {
-#if NETCORE
+#if NETSTANDARD1_5
             return type.GetTypeInfo().IsEnum;
 #else
             return type.IsEnum;
@@ -18,7 +18,7 @@ namespace DiscUtils.CoreCompat
 
         public static Attribute GetCustomAttribute(PropertyInfo property, Type attributeType)
         {
-#if NETCORE
+#if NETSTANDARD1_5
             return property.GetCustomAttribute(attributeType);
 #else
             return Attribute.GetCustomAttribute(property, attributeType);
@@ -27,7 +27,7 @@ namespace DiscUtils.CoreCompat
 
         public static Attribute GetCustomAttribute(PropertyInfo property, Type attributeType, bool inherit)
         {
-#if NETCORE
+#if NETSTANDARD1_5
             return property.GetCustomAttribute(attributeType, inherit);
 #else
             return Attribute.GetCustomAttribute(property, attributeType, inherit);
@@ -36,7 +36,7 @@ namespace DiscUtils.CoreCompat
 
         public static Attribute GetCustomAttribute(FieldInfo field, Type attributeType)
         {
-#if NETCORE
+#if NETSTANDARD1_5
             return field.GetCustomAttribute(attributeType);
 #else
             return Attribute.GetCustomAttribute(field, attributeType);
@@ -45,7 +45,7 @@ namespace DiscUtils.CoreCompat
 
         public static Attribute GetCustomAttribute(Type type, Type attributeType)
         {
-#if NETCORE
+#if NETSTANDARD1_5
             return type.GetTypeInfo().GetCustomAttribute(attributeType);
 #else
             return Attribute.GetCustomAttribute(type, attributeType);
@@ -54,7 +54,7 @@ namespace DiscUtils.CoreCompat
 
         public static Attribute GetCustomAttribute(Type type, Type attributeType, bool inherit)
         {
-#if NETCORE
+#if NETSTANDARD1_5
             return type.GetTypeInfo().GetCustomAttribute(attributeType, inherit);
 #else
             return Attribute.GetCustomAttribute(type, attributeType);
@@ -63,7 +63,7 @@ namespace DiscUtils.CoreCompat
 
         public static IEnumerable<Attribute> GetCustomAttributes(Type type, Type attributeType, bool inherit)
         {
-#if NETCORE
+#if NETSTANDARD1_5
             return type.GetTypeInfo().GetCustomAttributes(attributeType, inherit);
 #else
             return Attribute.GetCustomAttributes(type, attributeType);
@@ -72,7 +72,7 @@ namespace DiscUtils.CoreCompat
 
         public static Assembly GetAssembly(Type type)
         {
-#if NETCORE
+#if NETSTANDARD1_5
             return type.GetTypeInfo().Assembly;
 #else
             return type.Assembly;
@@ -81,7 +81,7 @@ namespace DiscUtils.CoreCompat
 
         public static int SizeOf<T>()
         {
-#if NETCORE
+#if NETSTANDARD1_5
             return Marshal.SizeOf<T>();
 #else
             return Marshal.SizeOf(typeof(T));

--- a/Library/DiscUtils.Core/DiscUtils.Core.csproj
+++ b/Library/DiscUtils.Core/DiscUtils.Core.csproj
@@ -15,30 +15,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <PackageReference Include="System.Security.AccessControl" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageReference Include="System.IO.FileSystem.DriveInfo" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Streams\DiscUtils.Streams.csproj" />
   </ItemGroup>

--- a/Library/DiscUtils.Core/DiscUtils.Core.csproj
+++ b/Library/DiscUtils.Core/DiscUtils.Core.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\DiscUtils.Streams\DiscUtils.Streams.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' or '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Security.AccessControl" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.DriveInfo" Version="4.3.0" />

--- a/Library/DiscUtils.Core/DiscUtils.Core.csproj
+++ b/Library/DiscUtils.Core/DiscUtils.Core.csproj
@@ -5,22 +5,21 @@
     <Description>Implementation of the ISO, UDF, FAT and NTFS file systems is now fairly stable. VHD, XVA, VMDK and VDI disk formats are implemented, as well as read/write Registry support. The library also includes a simple iSCSI initiator, for accessing disks via iSCSI and an NFS client implementation.</Description>
     <AssemblyTitle>DiscUtils (for .NET and .NET Core), core library that supports parts of DiscUtils</AssemblyTitle>
     <Authors>Kenneth Bell;Quamotion;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>DiscUtils.Core</AssemblyName>
     <PackageId>DiscUtils.Core</PackageId>
     <PackageTags>DiscUtils;VHD;VDI;XVA;VMDK;ISO;NTFS;EXT2FS</PackageTags>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\DiscUtils.Streams\DiscUtils.Streams.csproj" />
+  </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' or '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Security.AccessControl" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.DriveInfo" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <ProjectReference Include="..\DiscUtils.Streams\DiscUtils.Streams.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Dmg/DiscUtils.Dmg.csproj
+++ b/Library/DiscUtils.Dmg/DiscUtils.Dmg.csproj
@@ -12,4 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup></Project>
+  </ItemGroup>
+
+</Project>

--- a/Library/DiscUtils.Dmg/DiscUtils.Dmg.csproj
+++ b/Library/DiscUtils.Dmg/DiscUtils.Dmg.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils dmg parser. Works with apple disk (.dmg) files</Description>
     <AssemblyTitle>DiscUtils.Dmg</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Dmg</AssemblyName>
     <PackageId>DiscUtils.Dmg</PackageId>
     <PackageTags>DiscUtils;dmg</PackageTags>
@@ -13,20 +12,4 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-</Project>
+  </ItemGroup></Project>

--- a/Library/DiscUtils.Ext/DiscUtils.Ext.csproj
+++ b/Library/DiscUtils.Ext/DiscUtils.Ext.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils ext filesystem parser</Description>
     <AssemblyTitle>DiscUtils.Ext</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Ext</AssemblyName>
     <PackageId>DiscUtils.Ext</PackageId>
     <PackageTags>DiscUtils;Filesystem;ext</PackageTags>
@@ -13,20 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Fat/DiscUtils.Fat.csproj
+++ b/Library/DiscUtils.Fat/DiscUtils.Fat.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils FAT filesystem parser</Description>
     <AssemblyTitle>DiscUtils.Fat</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Fat</AssemblyName>
     <PackageId>DiscUtils.Fat</PackageId>
     <PackageTags>DiscUtils;Filesystem;FAT</PackageTags>
@@ -13,20 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.FileSystems/DiscUtils.FileSystems.csproj
+++ b/Library/DiscUtils.FileSystems/DiscUtils.FileSystems.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils, meta-package with filesystems</Description>
     <AssemblyTitle>DiscUtils.FileSystems</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.FileSystems</AssemblyName>
     <PackageId>DiscUtils.FileSystems</PackageId>
     <PackageTags>DiscUtils;Filesystem;NTFS;ext;Hfs+;HfsPlus;FAT</PackageTags>
@@ -20,20 +19,6 @@
     <ProjectReference Include="..\DiscUtils.OpticalDisk\DiscUtils.OpticalDisk.csproj" />
     <ProjectReference Include="..\DiscUtils.SquashFs\DiscUtils.SquashFs.csproj" />
     <ProjectReference Include="..\DiscUtils.Xfs\DiscUtils.Xfs.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.HfsPlus/DiscUtils.HfsPlus.csproj
+++ b/Library/DiscUtils.HfsPlus/DiscUtils.HfsPlus.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils Hfs+ filesystem parser</Description>
     <AssemblyTitle>DiscUtils.HfsPlus</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.HfsPlus</AssemblyName>
     <PackageId>DiscUtils.HfsPlus</PackageId>
     <PackageTags>DiscUtils;Filesystem;Hfs+;HfsPlus</PackageTags>
@@ -13,23 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Iscsi/DiscUtils.Iscsi.csproj
+++ b/Library/DiscUtils.Iscsi/DiscUtils.Iscsi.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />

--- a/Library/DiscUtils.Iscsi/DiscUtils.Iscsi.csproj
+++ b/Library/DiscUtils.Iscsi/DiscUtils.Iscsi.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils iSCSI</Description>
     <AssemblyTitle>DiscUtils.Iscsi</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Iscsi</AssemblyName>
     <PackageId>DiscUtils.Iscsi</PackageId>
     <PackageTags>DiscUtils;iSCSI</PackageTags>
@@ -19,20 +18,6 @@
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Iso9660/DiscUtils.Iso9660.csproj
+++ b/Library/DiscUtils.Iso9660/DiscUtils.Iso9660.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils Iso9660</Description>
     <AssemblyTitle>DiscUtils.Iso9660</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Iso9660</AssemblyName>
     <PackageId>DiscUtils.Iso9660</PackageId>
     <PackageTags>DiscUtils;Optical;Iso9660</PackageTags>
@@ -13,23 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Lvm/DiscUtils.Lvm.csproj
+++ b/Library/DiscUtils.Lvm/DiscUtils.Lvm.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils LVM</Description>
     <AssemblyTitle>DiscUtils.Lvm</AssemblyTitle>
     <Authors>Bianco Veigel</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Lvm</AssemblyName>
     <PackageId>DiscUtils.Lvm</PackageId>
     <PackageTags>DiscUtils;Lvm</PackageTags>
@@ -13,23 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Net/DiscUtils.Net.csproj
+++ b/Library/DiscUtils.Net/DiscUtils.Net.csproj
@@ -2,10 +2,10 @@
   <Import Project="../common.props" />
 
   <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net20;net40;net45</TargetFrameworks>
     <Description>DiscUtils NET</Description>
     <AssemblyTitle>DiscUtils.Net</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Net</AssemblyName>
     <PackageId>DiscUtils.Net</PackageId>
     <PackageTags>DiscUtils;NET;DNS</PackageTags>
@@ -13,20 +13,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Nfs/DiscUtils.Nfs.csproj
+++ b/Library/DiscUtils.Nfs/DiscUtils.Nfs.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>

--- a/Library/DiscUtils.Nfs/DiscUtils.Nfs.csproj
+++ b/Library/DiscUtils.Nfs/DiscUtils.Nfs.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils Nfs</Description>
     <AssemblyTitle>DiscUtils.Nfs</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Nfs</AssemblyName>
     <PackageId>DiscUtils.Nfs</PackageId>
     <PackageTags>DiscUtils;Nfs</PackageTags>
@@ -18,20 +17,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Ntfs/DiscUtils.Ntfs.csproj
+++ b/Library/DiscUtils.Ntfs/DiscUtils.Ntfs.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils NTFS filesystem parser</Description>
     <AssemblyTitle>DiscUtils.Ntfs</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Ntfs</AssemblyName>
     <PackageId>DiscUtils.Ntfs</PackageId>
     <PackageTags>DiscUtils;Filesystem;NTFS</PackageTags>
@@ -13,20 +12,4 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-</Project>
+  </ItemGroup></Project>

--- a/Library/DiscUtils.Ntfs/DiscUtils.Ntfs.csproj
+++ b/Library/DiscUtils.Ntfs/DiscUtils.Ntfs.csproj
@@ -12,4 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup></Project>
+  </ItemGroup>
+  
+</Project>

--- a/Library/DiscUtils.OpticalDiscSharing/DiscUtils.OpticalDiscSharing.csproj
+++ b/Library/DiscUtils.OpticalDiscSharing/DiscUtils.OpticalDiscSharing.csproj
@@ -2,10 +2,10 @@
   <Import Project="../common.props" />
 
   <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net20;net40;net45</TargetFrameworks>
     <Description>DiscUtils OpticalDiscSharing</Description>
     <AssemblyTitle>DiscUtils.OpticalDiscSharing</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.OpticalDiscSharing</AssemblyName>
     <PackageId>DiscUtils.OpticalDiscSharing</PackageId>
     <PackageTags>DiscUtils;OpticalDiscSharing</PackageTags>
@@ -14,20 +14,6 @@
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
     <ProjectReference Include="..\DiscUtils.Net\DiscUtils.Net.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.OpticalDisk/DiscUtils.OpticalDisk.csproj
+++ b/Library/DiscUtils.OpticalDisk/DiscUtils.OpticalDisk.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils OpticalDisk</Description>
     <AssemblyTitle>DiscUtils.OpticalDisk</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.OpticalDisk</AssemblyName>
     <PackageId>DiscUtils.OpticalDisk</PackageId>
     <PackageTags>DiscUtils;Optical;OpticalDisk</PackageTags>
@@ -15,20 +14,4 @@
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
     <ProjectReference Include="..\DiscUtils.Iso9660\DiscUtils.Iso9660.csproj" />
     <ProjectReference Include="..\DiscUtils.Udf\DiscUtils.Udf.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-</Project>
+  </ItemGroup></Project>

--- a/Library/DiscUtils.OpticalDisk/DiscUtils.OpticalDisk.csproj
+++ b/Library/DiscUtils.OpticalDisk/DiscUtils.OpticalDisk.csproj
@@ -14,4 +14,6 @@
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
     <ProjectReference Include="..\DiscUtils.Iso9660\DiscUtils.Iso9660.csproj" />
     <ProjectReference Include="..\DiscUtils.Udf\DiscUtils.Udf.csproj" />
-  </ItemGroup></Project>
+  </ItemGroup>
+
+</Project>

--- a/Library/DiscUtils.Registry/DiscUtils.Registry.csproj
+++ b/Library/DiscUtils.Registry/DiscUtils.Registry.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils Registry</Description>
     <AssemblyTitle>DiscUtils.Registry</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Registry</AssemblyName>
     <PackageId>DiscUtils.Registry</PackageId>
     <PackageTags>DiscUtils;Registry</PackageTags>
@@ -16,23 +15,9 @@
     <ProjectReference Include="..\DiscUtils.Streams\DiscUtils.Streams.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
     <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Sdi/DiscUtils.Sdi.csproj
+++ b/Library/DiscUtils.Sdi/DiscUtils.Sdi.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils Sdi</Description>
     <AssemblyTitle>DiscUtils.Sdi</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Sdi</AssemblyName>
     <PackageId>DiscUtils.Sdi</PackageId>
     <PackageTags>DiscUtils;Sdi</PackageTags>

--- a/Library/DiscUtils.Sdi/DiscUtils.Sdi.csproj
+++ b/Library/DiscUtils.Sdi/DiscUtils.Sdi.csproj
@@ -15,18 +15,4 @@
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
 </Project>

--- a/Library/DiscUtils.SquashFs/DiscUtils.SquashFs.csproj
+++ b/Library/DiscUtils.SquashFs/DiscUtils.SquashFs.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils SquashFs filesystem parser</Description>
     <AssemblyTitle>DiscUtils.SquashFs</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.SquashFs</AssemblyName>
     <PackageId>DiscUtils.SquashFs</PackageId>
     <PackageTags>DiscUtils;Filesystem;SquashFs</PackageTags>
@@ -13,20 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Streams/DiscUtils.Streams.csproj
+++ b/Library/DiscUtils.Streams/DiscUtils.Streams.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils Streams</Description>
     <AssemblyTitle>DiscUtils.Streams</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike;Bianco Veigel</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Streams</AssemblyName>
     <PackageId>DiscUtils.Streams</PackageId>
     <PackageTags>DiscUtils;Streams</PackageTags>

--- a/Library/DiscUtils.Swap/DiscUtils.Swap.csproj
+++ b/Library/DiscUtils.Swap/DiscUtils.Swap.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils Swap</Description>
     <AssemblyTitle>DiscUtils.Swap</AssemblyTitle>
     <Authors>Bianco Veigel</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Swap</AssemblyName>
     <PackageId>DiscUtils.Swap</PackageId>
     <PackageTags>DiscUtils;Swap</PackageTags>
@@ -13,23 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Transports/DiscUtils.Transports.csproj
+++ b/Library/DiscUtils.Transports/DiscUtils.Transports.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils, meta-package with transports, such as iSCSI and NFS</Description>
     <AssemblyTitle>DiscUtils.Transports</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Transports</AssemblyName>
     <PackageId>DiscUtils.Transports</PackageId>
     <PackageTags>DiscUtils;iSCSI;NFS</PackageTags>
@@ -16,23 +15,6 @@
     <ProjectReference Include="..\DiscUtils.Iscsi\DiscUtils.Iscsi.csproj" />
     <ProjectReference Include="..\DiscUtils.Nfs\DiscUtils.Nfs.csproj" />
     <ProjectReference Include="..\DiscUtils.OpticalDisk\DiscUtils.OpticalDisk.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Udf/DiscUtils.Udf.csproj
+++ b/Library/DiscUtils.Udf/DiscUtils.Udf.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils UDF filesystem parser.</Description>
     <AssemblyTitle>DiscUtils.Udf</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Udf</AssemblyName>
     <PackageId>DiscUtils.Udf</PackageId>
     <PackageTags>DiscUtils;Filesystem;UDF</PackageTags>
@@ -14,20 +13,6 @@
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
     <ProjectReference Include="..\DiscUtils.Iso9660\DiscUtils.Iso9660.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Vdi/DiscUtils.Vdi.csproj
+++ b/Library/DiscUtils.Vdi/DiscUtils.Vdi.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils Vdi</Description>
     <AssemblyTitle>DiscUtils.Vdi</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Vdi</AssemblyName>
     <PackageId>DiscUtils.Vdi</PackageId>
     <PackageTags>DiscUtils;Vdi</PackageTags>
@@ -13,20 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Vhd/DiscUtils.Vhd.csproj
+++ b/Library/DiscUtils.Vhd/DiscUtils.Vhd.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils VHD</Description>
     <AssemblyTitle>DiscUtils.Vhd</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Vhd</AssemblyName>
     <PackageId>DiscUtils.Vhd</PackageId>
     <PackageTags>DiscUtils;VHD</PackageTags>
@@ -13,20 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Vhdx/DiscUtils.Vhdx.csproj
+++ b/Library/DiscUtils.Vhdx/DiscUtils.Vhdx.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils VHDX</Description>
     <AssemblyTitle>DiscUtils.Vhdx</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Vhdx</AssemblyName>
     <PackageId>DiscUtils.Vhdx</PackageId>
     <PackageTags>DiscUtils;VHDX</PackageTags>
@@ -13,20 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Vmdk/DiscUtils.Vmdk.csproj
+++ b/Library/DiscUtils.Vmdk/DiscUtils.Vmdk.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils VMDK</Description>
     <AssemblyTitle>DiscUtils.Vmdk</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Vmdk</AssemblyName>
     <PackageId>DiscUtils.Vmdk</PackageId>
     <PackageTags>DiscUtils;VMDK</PackageTags>
@@ -13,20 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Wim/DiscUtils.Wim.csproj
+++ b/Library/DiscUtils.Wim/DiscUtils.Wim.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils WIM</Description>
     <AssemblyTitle>DiscUtils.Wim</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Wim</AssemblyName>
     <PackageId>DiscUtils.Wim</PackageId>
     <PackageTags>DiscUtils;WIM</PackageTags>
@@ -13,20 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Xfs/DiscUtils.Xfs.csproj
+++ b/Library/DiscUtils.Xfs/DiscUtils.Xfs.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils XFS</Description>
     <AssemblyTitle>DiscUtils.Xfs</AssemblyTitle>
     <Authors>Bianco Veigel</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Xfs</AssemblyName>
     <PackageId>DiscUtils.Xfs</PackageId>
     <PackageTags>DiscUtils;Xfs</PackageTags>
@@ -13,23 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Xva/DiscUtils.Xva.csproj
+++ b/Library/DiscUtils.Xva/DiscUtils.Xva.csproj
@@ -5,7 +5,6 @@
     <Description>DiscUtils XVA</Description>
     <AssemblyTitle>DiscUtils.Xva</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils.Xva</AssemblyName>
     <PackageId>DiscUtils.Xva</PackageId>
     <PackageTags>DiscUtils;XVA</PackageTags>
@@ -19,23 +18,6 @@
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XPath" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Xml" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Xva/DiscUtils.Xva.csproj
+++ b/Library/DiscUtils.Xva/DiscUtils.Xva.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' or '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XPath" Version="4.3.0" />

--- a/Library/DiscUtils.Xva/DiscUtils.Xva.csproj
+++ b/Library/DiscUtils.Xva/DiscUtils.Xva.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' or '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XPath" Version="4.3.0" />

--- a/Library/DiscUtils/DiscUtils.csproj
+++ b/Library/DiscUtils/DiscUtils.csproj
@@ -6,7 +6,6 @@
     <Description>DiscUtils, complete meta-package</Description>
     <AssemblyTitle>DiscUtils</AssemblyTitle>
     <Authors>Kenneth Bell;LordMike</Authors>
-    <TargetFrameworks>netstandard1.5;net20;net40;net45</TargetFrameworks>
     <AssemblyName>DiscUtils</AssemblyName>
     <PackageId>DiscUtils</PackageId>
     <PackageTags>DiscUtils</PackageTags>

--- a/Library/DiscUtils/DiscUtils.csproj
+++ b/Library/DiscUtils/DiscUtils.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <Import Project="../common.props" />
   
   <PropertyGroup>
@@ -42,21 +41,21 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
     <ProjectReference Include="..\DiscUtils.Net\DiscUtils.Net.csproj" />
     <ProjectReference Include="..\DiscUtils.OpticalDiscSharing\DiscUtils.OpticalDiscSharing.csproj" />
-    <Reference Include="System" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <ProjectReference Include="..\DiscUtils.Net\DiscUtils.Net.csproj" />
     <ProjectReference Include="..\DiscUtils.OpticalDiscSharing\DiscUtils.OpticalDiscSharing.csproj" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <ProjectReference Include="..\DiscUtils.Net\DiscUtils.Net.csproj" />
     <ProjectReference Include="..\DiscUtils.OpticalDiscSharing\DiscUtils.OpticalDiscSharing.csproj" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <ProjectReference Include="..\DiscUtils.Net\DiscUtils.Net.csproj" />
+    <ProjectReference Include="..\DiscUtils.OpticalDiscSharing\DiscUtils.OpticalDiscSharing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Library/common.props
+++ b/Library/common.props
@@ -4,6 +4,8 @@
     <VersionPrefix>0.14.2</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     
+    <TargetFrameworks>netstandard2.0;netstandard1.5;net40;net45</TargetFrameworks>
+    
     <PackageProjectUrl>https://github.com/DiscUtils/DiscUtils</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
@@ -41,8 +43,24 @@
   <!-- Constants -->
   <PropertyGroup>
     <DefineConstants Condition="'$(TargetFramework)' == 'netstandard1.5'">$(DefineConstants);NETCORE</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NETCORE</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net20'">$(DefineConstants);NET20</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net40'">$(DefineConstants);NET40</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net45'">$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
+
+  <!-- .NET dependencies -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
+    <Reference Include="System" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
 </Project>

--- a/Library/common.props
+++ b/Library/common.props
@@ -4,7 +4,7 @@
     <VersionPrefix>0.14.2</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     
-    <TargetFrameworks>netstandard2.0;netstandard1.5;net40;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.5;net20;net40;net45</TargetFrameworks>
     
     <PackageProjectUrl>https://github.com/DiscUtils/DiscUtils</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Library/common.props
+++ b/Library/common.props
@@ -48,19 +48,4 @@
     <DefineConstants Condition="'$(TargetFramework)' == 'net40'">$(DefineConstants);NET40</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net45'">$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
-
-  <!-- .NET dependencies -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
 </Project>

--- a/Tests/LibraryTests/LibraryTests.csproj
+++ b/Tests/LibraryTests/LibraryTests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp1.1;net452</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>LibraryTests</AssemblyName>
     <PackageId>LibraryTests</PackageId>


### PR DESCRIPTION
Adds `netstandard2.0` as a target framework.

As a result:
- A couple of projects which weren't supported on .NET Core (DiscUtils.Net, DiscUtils.Containers and DiscUtils.OpticalDiscSharing) now have a .NET Core equivalent
- The dependency graph on netstandard2.0 should be simplified

Also consolidated some code in `common.props`