### PR TITLE
Enable SourceLink support

### DIFF
--- a/Library/common.props
+++ b/Library/common.props
@@ -6,9 +6,19 @@
     
     <PackageProjectUrl>https://github.com/DiscUtils/DiscUtils</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/DiscUtils/DiscUtils/blob/master/LICENSE.txt</PackageLicenseUrl>
-    <RepositoryUrl>https://github.com/DiscUtils/DiscUtils</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
+
+  <!-- SourceLink support -->
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All"/>
+  </ItemGroup>
   
   <!-- Assembly stuff -->
   <PropertyGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,9 @@ artifacts:
 - path: '**\*.snupkg'
 deploy:
 - provider: NuGet
+  server: https://api.nuget.org/v3/index.json
+  symbol_server: https://api.nuget.org/v3/index.json
+  artifact: /.*\.s?nupkg/
   api_key:
     secure: 1zdVvAQJbpFDsKJS/TXQLc6GI6SlZueTSCcL7xbK6QMisvL8V5nhLFgrceLfp1Ak
   on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ install:
 - msbuild /t:Restore /Verbosity:Minimal /p:VersionSuffix=alpha
 artifacts:
 - path: '**\*.nupkg'
+- path: '**\*.snupkg'
 deploy:
 - provider: NuGet
   api_key:


### PR DESCRIPTION
Allows publishing of the source code of DiscUtils using a `.snupkg` package, and patching of the symbol files so that they reference the source code on GitHub.