### PR TITLE
Update package license information

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,28 +1,4 @@
 Copyright (c) 2008-2011, Kenneth Bell
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
---
-
-Certain files:
-
-
 Copyright (c) 2014, Quamotion
 
 Permission is hereby granted, free of charge, to any person obtaining a

--- a/Library/DiscUtils.BootConfig/DiscUtils.BootConfig.csproj
+++ b/Library/DiscUtils.BootConfig/DiscUtils.BootConfig.csproj
@@ -12,7 +12,6 @@
     <PackageId>DiscUtils.BootConfig</PackageId>
     <PackageTags>DiscUtils;BootConfig</PackageTags>
     <PackageProjectUrl>https://github.com/DiscUtils/DiscUtils</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/DiscUtils/DiscUtils/blob/master/LICENSE.txt</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/DiscUtils/DiscUtils</RepositoryUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Library/common.props
+++ b/Library/common.props
@@ -5,7 +5,7 @@
     <VersionSuffix>alpha</VersionSuffix>
     
     <PackageProjectUrl>https://github.com/DiscUtils/DiscUtils</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/DiscUtils/DiscUtils/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/DiscUtils/DiscUtils</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>


### PR DESCRIPTION
- Use the `PackageLicenseExpression` property so that NuGet can recognize the MIT license used
- Simplify the LICENSE.txt file, so that GitHub hopefully recognizes this as a MIT license