### PR TITLE
Use NerdBank.GitVersioning to calculate build numbers

### DIFF
--- a/Library/common.props
+++ b/Library/common.props
@@ -1,9 +1,6 @@
 <Project>
   <!-- Package related stuff -->
   <PropertyGroup>
-    <VersionPrefix>0.14.2</VersionPrefix>
-    <VersionSuffix>alpha</VersionSuffix>
-    
     <PackageProjectUrl>https://github.com/DiscUtils/DiscUtils</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/DiscUtils/DiscUtils/blob/master/LICENSE.txt</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/DiscUtils/DiscUtils</RepositoryUrl>
@@ -35,4 +32,9 @@
     <DefineConstants Condition="'$(TargetFramework)' == 'net40'">$(DefineConstants);NET40</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net45'">$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
+  
+  <!-- Automatic versioning -->
+  <ItemGroup>
+    <PackageReference Include="NerdBank.GitVersioning" Version="2.3.167" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/Library/version.json
+++ b/Library/version.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "0.14-alpha",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$",
+  ],
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ image: Visual Studio 2017
 build_script:
 - dotnet restore
 - msbuild /t:Build /p:Configuration=Release /Verbosity:Minimal
-- dotnet pack -c Release
+- msbuild /t:Pack /p:Configuration=Release
 test_script:
 - dotnet test Tests\LibraryTests\LibraryTests.csproj -c Release --no-build --logger:trx -- RunConfiguration.TargetPlatform="x64" RunConfiguration.DisableParallelization="true"
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,10 @@
 image: Visual Studio 2017
 build_script:
-- ps: >-
-    [xml]$doc = (Get-Content .\Library\DiscUtils.Core\DiscUtils.Core.csproj)
-
-    $version = $doc.Project.PropertyGroup.VersionPrefix
-
-    Update-AppveyorBuild -Version "$version build $env:APPVEYOR_BUILD_NUMBER"
-- cmd: REM Build
-- cmd: msbuild /t:Build /p:Configuration=Release /p:IncludeSymbols=True /Verbosity:Minimal /p:VersionSuffix=alpha
+- dotnet restore
+- dotnet build -c Release
+- dotnet pack -c Release
 test_script:
-- cmd: cd Tests\LibraryTests\bin\Release\netcoreapp1.1
-- cmd: dotnet test ..\..\..\LibraryTests.csproj -c Release --no-build --logger:trx -- RunConfiguration.TargetPlatform="x64" RunConfiguration.DisableParallelization="true"
-install:
-- msbuild /t:Restore /Verbosity:Minimal /p:VersionSuffix=alpha
+- dotnet test Tests\LibraryTests\LibraryTests.csproj -c Release --no-build --logger:trx -- RunConfiguration.TargetPlatform="x64" RunConfiguration.DisableParallelization="true"
 artifacts:
 - path: '**\*.nupkg'
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2017
 build_script:
 - dotnet restore
-- dotnet build -c Release
+- msbuild /t:Build /p:Configuration=Release /Verbosity:Minimal
 - dotnet pack -c Release
 test_script:
 - dotnet test Tests\LibraryTests\LibraryTests.csproj -c Release --no-build --logger:trx -- RunConfiguration.TargetPlatform="x64" RunConfiguration.DisableParallelization="true"


### PR DESCRIPTION
Right now, every build of DiscUtils has the same version number (as specific in `common.props`).

That can be inconvenient from time to time, for example if you want to take a NuGet package which was built by AppVeyor from master, as it will have the same version number (1.14.2-alpha) as what is currently available on NuGet.

This PR adds [NerdBank.GitVersioning](https://github.com/AArnott/Nerdbank.GitVersioning) as a build-time dependency.

It will automatically calculate the minor package version based on 'Git height' (every commit increments the minor version number by one). Builds from branches will also include the Git commit hash in the build number.

It also includes information such as the Git commit hash in the assembly information (so it's easier to figure out from which build a version was created), and creates an internal `ThisAssembly` class which you can use to access this information from code, if you want.

To bump the version number, update `version.json` instead of `common.props`.