### PR TITLE
Cleanup conditional compilation

### DIFF
--- a/Library/DiscUtils.Core/CoreCompat/EncodingHelper.cs
+++ b/Library/DiscUtils.Core/CoreCompat/EncodingHelper.cs
@@ -1,4 +1,4 @@
-﻿#if NETCORE
+﻿#if NETSTANDARD
 using System.Text;
 #endif
 
@@ -15,7 +15,7 @@ namespace DiscUtils.CoreCompat
 
             _registered = true;
 
-#if NETCORE
+#if NETSTANDARD
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 #endif
         }

--- a/Library/DiscUtils.Core/CoreCompat/StringExtensions.cs
+++ b/Library/DiscUtils.Core/CoreCompat/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NETCORE
+﻿#if NETSTANDARD1_5
 using System.Globalization;
 
 namespace DiscUtils.CoreCompat

--- a/Library/DiscUtils.Core/DiscFileSystem.cs
+++ b/Library/DiscUtils.Core/DiscFileSystem.cs
@@ -30,7 +30,7 @@ namespace DiscUtils
     /// Provides the base class for all file systems.
     /// </summary>
     public abstract class DiscFileSystem :
-#if !NETCORE
+#if !NETSTANDARD
         MarshalByRefObject, 
 #endif
         IFileSystem, IDisposable

--- a/Library/DiscUtils.Core/Internal/LocalFileLocator.cs
+++ b/Library/DiscUtils.Core/Internal/LocalFileLocator.cs
@@ -54,7 +54,7 @@ namespace DiscUtils.Internal
             string combinedPath = Path.Combine(_dir, path);
             if (string.IsNullOrEmpty(combinedPath))
             {
-#if NETCORE
+#if NETSTANDARD1_5
                 return Directory.GetCurrentDirectory();
 #else
                 return Environment.CurrentDirectory;

--- a/Library/DiscUtils.Core/InvalidFileSystemException.cs
+++ b/Library/DiscUtils.Core/InvalidFileSystemException.cs
@@ -23,7 +23,7 @@
 using System;
 using System.IO;
 
-#if !NETCORE
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 
@@ -32,7 +32,7 @@ namespace DiscUtils
     /// <summary>
     /// Exception thrown when some invalid file system data is found, indicating probably corruption.
     /// </summary>
-#if !NETCORE
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class InvalidFileSystemException : IOException
@@ -57,13 +57,12 @@ namespace DiscUtils
         public InvalidFileSystemException(string message, Exception innerException)
             : base(message, innerException) {}
 
-#if !NETCORE
-
-/// <summary>
-/// Initializes a new instance of the InvalidFileSystemException class.
-/// </summary>
-/// <param name="info">The serialization info.</param>
-/// <param name="context">The streaming context.</param>
+#if !NETSTANDARD1_5
+        /// <summary>
+        /// Initializes a new instance of the InvalidFileSystemException class.
+        /// </summary>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         protected InvalidFileSystemException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Library/DiscUtils.Core/Plist.cs
+++ b/Library/DiscUtils.Core/Plist.cs
@@ -34,7 +34,7 @@ namespace DiscUtils
         internal static Dictionary<string, object> Parse(Stream stream)
         {
             XmlDocument xmlDoc = new XmlDocument();
-#if !NETCORE
+#if !NETSTANDARD1_5
             xmlDoc.XmlResolver = null;
 #endif
 
@@ -63,14 +63,14 @@ namespace DiscUtils
         internal static void Write(Stream stream, Dictionary<string, object> plist)
         {
             XmlDocument xmlDoc = new XmlDocument();
-#if !NETCORE
+#if !NETSTANDARD1_5
             xmlDoc.XmlResolver = null;
 #endif
 
             XmlDeclaration xmlDecl = xmlDoc.CreateXmlDeclaration("1.0", "UTF-8", null);
             xmlDoc.AppendChild(xmlDecl);
 
-#if !NETCORE
+#if !NETSTANDARD1_5
             XmlDocumentType xmlDocType = xmlDoc.CreateDocumentType("plist", "-//Apple//DTD PLIST 1.0//EN", "http://www.apple.com/DTDs/PropertyList-1.0.dtd", null);
             xmlDoc.AppendChild(xmlDocType);
 #endif

--- a/Library/DiscUtils.Core/System/DateTimeOffsetExtensions.cs
+++ b/Library/DiscUtils.Core/System/DateTimeOffsetExtensions.cs
@@ -17,7 +17,7 @@
         /// <returns>DateTimeOffset.</returns>
         public static DateTimeOffset FromUnixTimeSeconds(this long seconds)
         {
-#if NETCORE
+#if NETSTANDARD
             return DateTimeOffset.FromUnixTimeSeconds(seconds);
 #else
             DateTimeOffset dateTimeOffset = new DateTimeOffset(DateTimeOffsetExtensions.UnixEpoch);
@@ -26,7 +26,7 @@
 #endif
         }
 
-#if !NETCORE
+#if !NETSTANDARD1_5
         /// <summary>
         /// Converts the current DateTimeOffset to Unix time.
         /// </summary>

--- a/Library/DiscUtils.Core/VirtualDisk.cs
+++ b/Library/DiscUtils.Core/VirtualDisk.cs
@@ -34,7 +34,7 @@ namespace DiscUtils
     /// Base class representing virtual hard disks.
     /// </summary>
     public abstract class VirtualDisk :
-#if !NETCORE
+#if !NETSTANDARD
         MarshalByRefObject, 
 #endif
         IDisposable

--- a/Library/DiscUtils.Core/VolumeInfo.cs
+++ b/Library/DiscUtils.Core/VolumeInfo.cs
@@ -31,7 +31,7 @@ namespace DiscUtils
     /// Base class that holds information about a disk volume.
     /// </summary>
     public abstract class VolumeInfo
-#if !NETCORE
+#if !NETSTANDARD
         : MarshalByRefObject
 #endif
     {

--- a/Library/DiscUtils.Core/VolumeInfo.cs
+++ b/Library/DiscUtils.Core/VolumeInfo.cs
@@ -20,7 +20,7 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-#if !NETCORE
+#if !NETSTANDARD
 using System;
 #endif
 using DiscUtils.Streams;

--- a/Library/DiscUtils.Core/VolumeManager.cs
+++ b/Library/DiscUtils.Core/VolumeManager.cs
@@ -42,7 +42,7 @@ namespace DiscUtils
     /// ways for data redundancy or other purposes.</para>
     /// </remarks>
     public sealed class VolumeManager
-#if !NETCORE
+#if !NETSTANDARD
         : MarshalByRefObject
 #endif
     {

--- a/Library/DiscUtils.Iscsi/Connection.cs
+++ b/Library/DiscUtils.Iscsi/Connection.cs
@@ -46,7 +46,7 @@ namespace DiscUtils.Iscsi
             Session = session;
             _authenticators = authenticators;
 
-#if NETCORE
+#if NETSTANDARD1_5
             TcpClient client = new TcpClient();
             client.ConnectAsync(address.NetworkAddress, address.NetworkPort).Wait();
 #else

--- a/Library/DiscUtils.Iscsi/InvalidProtocolException.cs
+++ b/Library/DiscUtils.Iscsi/InvalidProtocolException.cs
@@ -22,7 +22,7 @@
 
 using System;
 
-#if !NETCORE
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 
@@ -31,7 +31,7 @@ namespace DiscUtils.Iscsi
     /// <summary>
     /// Exception thrown when a low-level iSCSI failure is detected.
     /// </summary>
-#if !NETCORE
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class InvalidProtocolException : IscsiException
@@ -56,13 +56,12 @@ namespace DiscUtils.Iscsi
         public InvalidProtocolException(string message, Exception innerException)
             : base(message, innerException) {}
 
-#if !NETCORE
-
-/// <summary>
-/// Initializes a new instance of the InvalidProtocolException class.
-/// </summary>
-/// <param name="info">The serialization info.</param>
-/// <param name="context">Ther context.</param>
+#if !NETSTANDARD1_5
+        /// <summary>
+        /// Initializes a new instance of the InvalidProtocolException class.
+        /// </summary>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">Ther context.</param>
         protected InvalidProtocolException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Library/DiscUtils.Iscsi/IscsiException.cs
+++ b/Library/DiscUtils.Iscsi/IscsiException.cs
@@ -25,14 +25,14 @@ using System.IO;
 
 namespace DiscUtils.Iscsi
 {
-#if !NETCORE
+#if !NETSTANDARD1_5
     using System.Runtime.Serialization;
 #endif
 
     /// <summary>
     /// Base exception for any iSCSI-related failures.
     /// </summary>
-#if !NETCORE
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class IscsiException : IOException
@@ -57,13 +57,12 @@ namespace DiscUtils.Iscsi
         public IscsiException(string message, Exception innerException)
             : base(message, innerException) {}
 
-#if !NETCORE
-
-/// <summary>
-/// Initializes a new instance of the IscsiException class.
-/// </summary>
-/// <param name="info">The serialization info.</param>
-/// <param name="context">Ther context.</param>
+#if !NETSTANDARD1_5
+        /// <summary>
+        /// Initializes a new instance of the IscsiException class.
+        /// </summary>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">Ther context.</param>
         protected IscsiException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Library/DiscUtils.Iscsi/LoginException.cs
+++ b/Library/DiscUtils.Iscsi/LoginException.cs
@@ -24,14 +24,14 @@ using System;
 
 namespace DiscUtils.Iscsi
 {
-#if !NETCORE
+#if !NETSTANDARD1_5
     using System.Runtime.Serialization;
 #endif
 
     /// <summary>
     /// Exception thrown when an authentication exception occurs.
     /// </summary>
-#if !NETCORE
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class LoginException : IscsiException
@@ -64,13 +64,12 @@ namespace DiscUtils.Iscsi
         public LoginException(string message, LoginStatusCode code)
             : base("iSCSI login failure (" + code + "):" + message) {}
 
-#if !NETCORE
-
-/// <summary>
-/// Initializes a new instance of the LoginException class.
-/// </summary>
-/// <param name="info">The serialization info.</param>
-/// <param name="context">Ther context.</param>
+#if !NETSTANDARD1_5
+        /// <summary>
+        /// Initializes a new instance of the LoginException class.
+        /// </summary>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">Ther context.</param>
         protected LoginException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Library/DiscUtils.Iscsi/ScsiCommandException.cs
+++ b/Library/DiscUtils.Iscsi/ScsiCommandException.cs
@@ -22,7 +22,7 @@
 
 using System;
 
-#if !NETCORE
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 using System.Security.Permissions;
 #endif
@@ -32,7 +32,7 @@ namespace DiscUtils.Iscsi
     /// <summary>
     /// Exception thrown when a low-level iSCSI failure is detected.
     /// </summary>
-#if !NETCORE
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class ScsiCommandException : IscsiException
@@ -113,13 +113,12 @@ namespace DiscUtils.Iscsi
             Status = status;
         }
 
-#if !NETCORE
-
-/// <summary>
-/// Initializes a new instance of the ScsiCommandException class.
-/// </summary>
-/// <param name="info">The serialization info.</param>
-/// <param name="context">Ther context.</param>
+#if !NETSTANDARD1_5
+        /// <summary>
+        /// Initializes a new instance of the ScsiCommandException class.
+        /// </summary>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">Ther context.</param>
         protected ScsiCommandException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -133,14 +132,15 @@ namespace DiscUtils.Iscsi
         /// </summary>
         public ScsiStatus Status { get; }
 
-#if !NETCORE
-
-/// <summary>
-/// Gets the serialized state of this exception.
-/// </summary>
-/// <param name="info">The serialization info.</param>
-/// <param name="context">The serialization context.</param>
+        /// <summary>
+        /// Gets the serialized state of this exception.
+        /// </summary>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The serialization context.</param>
+#if !NETSTANDARD1_5
+#if !NETSTANDARD
         [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.SerializationFormatter)]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/Library/DiscUtils.Nfs/Nfs3Exception.cs
+++ b/Library/DiscUtils.Nfs/Nfs3Exception.cs
@@ -23,7 +23,7 @@
 using System;
 using System.IO;
 
-#if !NETCORE
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 using System.Security.Permissions;
 #endif
@@ -33,7 +33,7 @@ namespace DiscUtils.Nfs
     /// <summary>
     /// Exception thrown when some invalid file system data is found, indicating probably corruption.
     /// </summary>
-#if !NETCORE
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public sealed class Nfs3Exception : IOException
@@ -79,7 +79,7 @@ namespace DiscUtils.Nfs
             NfsStatus = status;
         }
 
-#if !NETCORE
+#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the Nfs3Exception class.
         /// </summary>
@@ -97,7 +97,7 @@ namespace DiscUtils.Nfs
         /// </summary>
         public Nfs3Status NfsStatus { get; } = Nfs3Status.Unknown;
 
-#if !NETCORE
+#if !NETSTANDARD1_5
         /// <summary>
         /// Serializes this exception.
         /// </summary>

--- a/Library/DiscUtils.Nfs/RpcException.cs
+++ b/Library/DiscUtils.Nfs/RpcException.cs
@@ -26,14 +26,14 @@ using System.IO;
 
 namespace DiscUtils.Nfs
 {
-#if !NETCORE
+#if !NETSTANDARD1_5
     using System.Runtime.Serialization;
 #endif
 
     /// <summary>
     /// Exception thrown when some invalid file system data is found, indicating probably corruption.
     /// </summary>
-#if !NETCORE
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public sealed class RpcException : IOException
@@ -65,13 +65,12 @@ namespace DiscUtils.Nfs
         internal RpcException(RpcReplyHeader reply)
             : base(GenerateMessage(reply)) {}
 
-#if !NETCORE
-
-/// <summary>
-/// Initializes a new instance of the RpcException class.
-/// </summary>
-/// <param name="info">The serialization info.</param>
-/// <param name="context">The streaming context.</param>
+#if !NETSTANDARD1_5
+        /// <summary>
+        /// Initializes a new instance of the RpcException class.
+        /// </summary>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         private RpcException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Library/DiscUtils.Nfs/RpcTcpTransport.cs
+++ b/Library/DiscUtils.Nfs/RpcTcpTransport.cs
@@ -61,7 +61,7 @@ namespace DiscUtils.Nfs
 
             if (_socket != null)
             {
-#if NETCORE
+#if NETSTANDARD
                 _socket.Dispose();
 #else
                 _socket.Close();
@@ -97,7 +97,7 @@ namespace DiscUtils.Nfs
 
                         if (_socket != null)
                         {
-#if NETCORE
+#if NETSTANDARD
                             _socket.Dispose();
 #else
                             _socket.Close();
@@ -152,7 +152,7 @@ namespace DiscUtils.Nfs
 
                         _tcpStream.Dispose();
                         _tcpStream = null;
-#if NETCORE
+#if NETSTANDARD
                         _socket.Dispose();
 #else
                         _socket.Close();

--- a/Library/DiscUtils.Ntfs/NtfsFileSystemChecker.cs
+++ b/Library/DiscUtils.Ntfs/NtfsFileSystemChecker.cs
@@ -27,7 +27,7 @@ using System.IO;
 using System.Text;
 using DiscUtils.Streams;
 
-#if !NETCORE
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 

--- a/Library/DiscUtils.Ntfs/NtfsFileSystemChecker.cs
+++ b/Library/DiscUtils.Ntfs/NtfsFileSystemChecker.cs
@@ -624,7 +624,7 @@ namespace DiscUtils.Ntfs
             }
         }
 
-#if !NETCORE
+#if !NETSTANDARD1_5
         [Serializable]
 #endif
         private sealed class AbortException : InvalidFileSystemException

--- a/Library/DiscUtils.Registry/RegistryCorruptException.cs
+++ b/Library/DiscUtils.Registry/RegistryCorruptException.cs
@@ -24,14 +24,14 @@ using System;
 
 namespace DiscUtils.Registry
 {
-#if !NETCORE
+#if !NETSTANDARD1_5
     using System.Runtime.Serialization;
 #endif
 
     /// <summary>
     /// Exception thrown when some corruption is found in the registry hive.
     /// </summary>
-#if !NETCORE
+#if !NETSTANDARD1_5
     [Serializable]
 #endif
     public class RegistryCorruptException : Exception
@@ -56,13 +56,12 @@ namespace DiscUtils.Registry
         public RegistryCorruptException(string message, Exception innerException)
             : base(message, innerException) {}
 
-#if !NETCORE
-
-/// <summary>
-/// Initializes a new instance of the RegistryCorruptException class.
-/// </summary>
-/// <param name="info">The serialization info.</param>
-/// <param name="context">The streaming context.</param>
+#if !NETSTANDARD1_5
+        /// <summary>
+        /// Initializes a new instance of the RegistryCorruptException class.
+        /// </summary>
+        /// <param name="info">The serialization info.</param>
+        /// <param name="context">The streaming context.</param>
         protected RegistryCorruptException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Library/DiscUtils.Streams/Buffer/Buffer.cs
+++ b/Library/DiscUtils.Streams/Buffer/Buffer.cs
@@ -21,9 +21,8 @@
 //
 
 using System.Collections.Generic;
-
-#if !NETCORE
-    using System;
+#if !NETSTANDARD
+using System;
 #endif
 
 namespace DiscUtils.Streams
@@ -32,7 +31,7 @@ namespace DiscUtils.Streams
     /// Abstract base class for implementations of IBuffer.
     /// </summary>
     public abstract class Buffer :
-#if !NETCORE
+#if !NETSTANDARD
         MarshalByRefObject, 
 #endif
         IBuffer

--- a/Library/DiscUtils.Vhd/FileChecker.cs
+++ b/Library/DiscUtils.Vhd/FileChecker.cs
@@ -24,7 +24,7 @@ using System;
 using System.IO;
 using DiscUtils.Internal;
 using DiscUtils.Streams;
-#if !NETCORE
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 #endif
 
@@ -418,7 +418,7 @@ namespace DiscUtils.Vhd
             }
         }
 
-#if !NETCORE
+#if !NETSTANDARD1_5
         [Serializable]
 #endif
         private sealed class AbortException : InvalidFileSystemException

--- a/Library/DiscUtils.Vhdx/Metadata.cs
+++ b/Library/DiscUtils.Vhdx/Metadata.cs
@@ -25,8 +25,8 @@ using System.IO;
 using System.Runtime.InteropServices;
 using DiscUtils.CoreCompat;
 using DiscUtils.Streams;
-#if !NETCORE
-    using System.Security.Permissions;
+#if !NETSTANDARD
+using System.Security.Permissions;
 #endif
 
 namespace DiscUtils.Vhdx
@@ -117,10 +117,9 @@ namespace DiscUtils.Vhdx
             return entry.Length;
         }
 
-#if !NETCORE
+#if !NETSTANDARD
         [SecurityPermission(SecurityAction.Demand, UnmanagedCode = true)]
 #endif
-
         private static uint AddEntryValue<T>(T data, Writer<T> writer, Guid id, MetadataEntryFlags flags,
                                              MetadataTable header, uint dataOffset, Stream stream)
         {
@@ -156,10 +155,9 @@ namespace DiscUtils.Vhdx
             return default(T);
         }
 
-#if !NETCORE
+#if !NETSTANDARD
         [SecurityPermission(SecurityAction.Demand, UnmanagedCode = true)]
 #endif
-
         private T ReadValue<T>(Guid itemId, bool isUser, Reader<T> reader)
         {
             MetadataEntryKey key = new MetadataEntryKey(itemId, isUser);

--- a/Library/DiscUtils.Xva/HashStreamCore.cs
+++ b/Library/DiscUtils.Xva/HashStreamCore.cs
@@ -27,7 +27,7 @@ using DiscUtils.Streams;
 
 namespace DiscUtils.Xva
 {
-#if NETCORE
+#if NETSTANDARD
     internal class HashStreamCore : Stream
     {
         private readonly IncrementalHash _hashAlg;

--- a/Library/DiscUtils.Xva/VirtualMachineBuilder.cs
+++ b/Library/DiscUtils.Xva/VirtualMachineBuilder.cs
@@ -139,7 +139,7 @@ namespace DiscUtils.Xva
                             }
 
                             Stream chunkHashStream;
-#if NETCORE
+#if NETSTANDARD
                             IncrementalHash hashAlgCore = IncrementalHash.CreateHash(HashAlgorithmName.SHA1);
                             chunkHashStream = new HashStreamCore(chunkStream, Ownership.Dispose, hashAlgCore);
 #else
@@ -150,7 +150,7 @@ namespace DiscUtils.Xva
                             tarBuilder.AddFile(string.Format(CultureInfo.InvariantCulture, "Ref:{0}/{1:D8}", diskIds[diskIdx], i), chunkHashStream);
 
                             byte[] hash;
-#if NETCORE
+#if NETSTANDARD
                             hash = hashAlgCore.GetHashAndReset();
 #else
                             hashAlgDotnet.TransformFinalBlock(new byte[0], 0, 0);
@@ -173,7 +173,7 @@ namespace DiscUtils.Xva
                     Stream chunkStream = new ZeroStream(Sizes.OneMiB);
 
                     Stream chunkHashStream;
-#if NETCORE
+#if NETSTANDARD
                     IncrementalHash hashAlgCore = IncrementalHash.CreateHash(HashAlgorithmName.SHA1);
                     chunkHashStream = new HashStreamCore(chunkStream, Ownership.Dispose, hashAlgCore);
 #else
@@ -184,7 +184,7 @@ namespace DiscUtils.Xva
                     tarBuilder.AddFile(string.Format(CultureInfo.InvariantCulture, "Ref:{0}/{1:D8}", diskIds[diskIdx], lastActualChunk), chunkHashStream);
 
                     byte[] hash;
-#if NETCORE
+#if NETSTANDARD
                     hash = hashAlgCore.GetHashAndReset();
 #else
                     hashAlgDotnet.TransformFinalBlock(new byte[0], 0, 0);

--- a/Library/DiscUtils/SetupHelper.cs
+++ b/Library/DiscUtils/SetupHelper.cs
@@ -16,7 +16,7 @@ using DiscUtils.Udf;
 using DiscUtils.Wim;
 using DiscUtils.Xfs;
 
-#if !NETCORE
+#if !NETSTANDARD1_5
 using DiscUtils.Net.Dns;
 using DiscUtils.OpticalDiscSharing;
 #endif
@@ -35,12 +35,12 @@ namespace DiscUtils.Complete
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(HfsPlusFileSystem)));
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(Iscsi.Disk)));
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(BuildFileInfo)));
-#if !NETCORE
+#if !NETSTANDARD1_5
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(DnsClient)));
 #endif
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(Nfs3Status)));
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(NtfsFileSystem)));
-#if !NETCORE
+#if !NETSTANDARD1_5
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(DiscInfo)));
 #endif
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(Disc)));

--- a/Library/common.props
+++ b/Library/common.props
@@ -39,13 +39,4 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
   </PropertyGroup>
-  
-  <!-- Constants -->
-  <PropertyGroup>
-    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard1.5'">$(DefineConstants);NETCORE</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NETCORE</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'net20'">$(DefineConstants);NET20</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'net40'">$(DefineConstants);NET40</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'net45'">$(DefineConstants);NET45</DefineConstants>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Use standardized preprocessor variables (`NETSTANDARD`, `NETSTANDARD1_5`, `NETSTANDARD2_0`, `NET20`, `NET45`,...) instead of custom ones
- Don't use CAS or MarshalByRef on .NET Core at all
- Don't use serialization on .NET Core 1.x, but do enable it on .NET Core 2.x