### PR TITLE
Fix bug in XFS B+tree inode

### DIFF
--- a/Library/DiscUtils.Xfs/BTreeExtentHeader.cs
+++ b/Library/DiscUtils.Xfs/BTreeExtentHeader.cs
@@ -40,18 +40,15 @@ namespace DiscUtils.Xfs
 
         public long RightSibling { get; private set; }
 
-        public virtual int Size
-        {
-            get { return 24; }
-        }
+        public virtual int Size => 24;
 
         public virtual int ReadFrom(byte[] buffer, int offset)
         {
             Magic = EndianUtilities.ToUInt32BigEndian(buffer, offset);
             Level = EndianUtilities.ToUInt16BigEndian(buffer, offset + 0x4);
             NumberOfRecords = EndianUtilities.ToUInt16BigEndian(buffer, offset + 0x6);
-            LeftSibling = EndianUtilities.ToInt64BigEndian(buffer, offset + 0x8);
-            RightSibling = EndianUtilities.ToInt64BigEndian(buffer, offset + 0xC);
+            LeftSibling = EndianUtilities.ToInt32BigEndian(buffer, offset + 0x8);
+            RightSibling = EndianUtilities.ToInt32BigEndian(buffer, offset + 0xC);
             return 24;
         }
 

--- a/Library/DiscUtils.Xfs/Inode.cs
+++ b/Library/DiscUtils.Xfs/Inode.cs
@@ -31,6 +31,7 @@ namespace DiscUtils.Xfs
     {
         public Inode(ulong number, Context context)
         {
+            Number = number;
             var sb = context.SuperBlock;
             RelativeInodeNumber = (uint) (number & sb.RelativeInodeMask);
             AllocationGroup = (uint) ((number & sb.AgInodeMask) >> (sb.AgBlocksLog2 + sb.InodesPerBlockLog2));
@@ -56,6 +57,8 @@ namespace DiscUtils.Xfs
         public uint AgBlock { get; private set; }
 
         public uint BlockOffset { get; private set; }
+
+        public ulong Number { get; }
 
         public const ushort InodeMagic = 0x494e;
         /// <summary>
@@ -318,6 +321,11 @@ namespace DiscUtils.Xfs
                 builderExtents.Add(new BuilderSparseStreamExtent((long) extent.StartOffset * context.SuperBlock.Blocksize, substream));
             }
             return new StreamBuffer(new ExtentStream((long) this.Length, builderExtents), Ownership.Dispose);
+        }
+
+        public override string ToString()
+        {
+            return "inode " + Number;
         }
     }
 }


### PR DESCRIPTION
In XFS source code, bb_leftsib and bb_rightsib (declared in xfs_format.h) are both of type __be32, which is an unsigned int32 (and not 64).
While I was there, I added Inode.ToString() to help me differentiate between inodes: In Linux, inodes are identified by a unique ID.

Branch: [xfs-btree-bugfix]