### PR TITLE
Support building with dotnet build, Linux

### DIFF
--- a/Library/DiscUtils.Net/DiscUtils.Net.csproj
+++ b/Library/DiscUtils.Net/DiscUtils.Net.csproj
@@ -2,7 +2,6 @@
   <Import Project="../common-library.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net20;net40;net45</TargetFrameworks>
     <Description>DiscUtils NET</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;NET;DNS</PackageTags>

--- a/Library/DiscUtils.OpticalDiscSharing/DiscUtils.OpticalDiscSharing.csproj
+++ b/Library/DiscUtils.OpticalDiscSharing/DiscUtils.OpticalDiscSharing.csproj
@@ -2,7 +2,6 @@
   <Import Project="../common-library.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net20;net40;net45</TargetFrameworks>
     <Description>DiscUtils OpticalDiscSharing</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;OpticalDiscSharing</PackageTags>

--- a/Library/common-library.props
+++ b/Library/common-library.props
@@ -3,7 +3,7 @@
   
   <!-- Package related stuff -->
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.5;net40;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net40;net45</TargetFrameworks>
     <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net20</TargetFrameworks>
     
     <PackageProjectUrl>https://github.com/DiscUtils/DiscUtils</PackageProjectUrl>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
   
   <!-- Assembly stuff -->

--- a/Library/common-library.props
+++ b/Library/common-library.props
@@ -3,7 +3,8 @@
   
   <!-- Package related stuff -->
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.5;net20;net40;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.5;net40;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net20</TargetFrameworks>
     
     <PackageProjectUrl>https://github.com/DiscUtils/DiscUtils</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Tests/LibraryTests/LibraryTests.csproj
+++ b/Tests/LibraryTests/LibraryTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-tests.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>LibraryTests</AssemblyName>
     <PackageId>LibraryTests</PackageId>

--- a/Utilities/DiscUtils.Common/DiscUtils.Common.csproj
+++ b/Utilities/DiscUtils.Common/DiscUtils.Common.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
     <DebugType>portable</DebugType>
   </PropertyGroup>
 

--- a/Utilities/DiscUtils.Diagnostics/DiscUtils.Diagnostics.csproj
+++ b/Utilities/DiscUtils.Diagnostics/DiscUtils.Diagnostics.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>


### PR DESCRIPTION
This enables checking cloning DiscUtils on say, macOS or Linux building with `dotnet build` without having to change of the project files.

- Only target `net20` when using full MSBuild (`MSBuildRuntimeType == Full`)
- Only target `net40` & `net45` when building on Windows (`OS == Windows_NT`)