### PR TITLE
Use auto-generated assembly attributes

### DIFF
--- a/Library/DiscUtils.BootConfig/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.BootConfig/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.BootConfig")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Containers/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Containers/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Containers")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Core/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Core/Properties/AssemblyInfo.cs
@@ -21,21 +21,9 @@
 //
 
 using System;
-using System.Reflection;
 using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyTitle("DiscUtils")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Kenneth Bell")]
-[assembly: AssemblyProduct("DiscUtils")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Library/DiscUtils.Dmg/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Dmg/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Dmg")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Ext/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Ext/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Ext")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Fat/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Fat/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Fat")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.FileSystems/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.FileSystems/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.FileSystems")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.HfsPlus/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.HfsPlus/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.HfsPlus")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Iscsi/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Iscsi/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Isci")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Iso9660/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Iso9660/Properties/AssemblyInfo.cs
@@ -1,15 +1,5 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Iso9660")]
-[assembly: AssemblyTrademark("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Net/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Net/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Net")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Nfs/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Nfs/Properties/AssemblyInfo.cs
@@ -1,15 +1,6 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Nfs")]
-[assembly: AssemblyTrademark("")]
 [assembly: InternalsVisibleTo("LibraryTests, PublicKey=002400000480000094000000060200000024000052534131000400000100010047ebec172a9831bb20fede77e17d784026ea7030d7055f2ae09576c71cebe77ebfab436d80580a4fcbba7242ff61bd52b686f5fe9d41fe7cd3e6c05b8a876eccf35b8ad7c5e3a6704295d7210b138d7280a6f72688419a65dd7a8612d66869f2e712c57c41fcc9196e4cb06d95d8e678f6967e65348c370405fb7eeb6aa1d3e8")]
 
 // Setting ComVisible to false makes the types in this assembly not visible

--- a/Library/DiscUtils.Ntfs/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Ntfs/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Ntfs")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.OpticalDiscSharing/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.OpticalDiscSharing/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.OpticalDiskSharing")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.OpticalDisk/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.OpticalDisk/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Optical")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Registry/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Registry/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Registry")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Sdi/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Sdi/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Sdi")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.SquashFs/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.SquashFs/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.SquashFs")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Streams/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Streams/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Streams")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Transports/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Transports/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Transports")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Udf/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Udf/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Udf")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Vdi/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Vdi/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Vdi")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Vhd/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Vhd/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Vhd")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Vhdx/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Vhdx/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Vhdx")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Vmdk/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Vmdk/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Vmdk")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Wim/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Wim/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Wim")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils.Xva/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Xva/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Xva")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/DiscUtils/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils/Properties/AssemblyInfo.cs
@@ -1,14 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("DiscUtils.Complete")]
-[assembly: AssemblyTrademark("")]
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Library/common-library.props
+++ b/Library/common-library.props
@@ -22,15 +22,6 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
   
-  <!-- Assembly stuff -->
-  <PropertyGroup>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
-  </PropertyGroup>
-  
   <!-- Assembly Signing -->
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)../SigningKey.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
The .NET Core SDK can autogenerate these attributes, which makes for less code to maintain.