### PR TITLE
lvm pv detection

### DIFF
--- a/Library/DiscUtils.Lvm/LogicalVolumeManager.cs
+++ b/Library/DiscUtils.Lvm/LogicalVolumeManager.cs
@@ -85,7 +85,7 @@ namespace DiscUtils.Lvm
             if (partition == null) return false;
             return partition.BiosType == BiosPartitionTypes.LinuxLvm ||
                    partition.GuidType == GuidPartitionTypes.LinuxLvm ||
-                   PhysicalVolume.TryOpen(partition, out _);
+                   PhysicalVolume.CanOpen(partition);
         }
 
         /// <summary>

--- a/Library/DiscUtils.Lvm/LogicalVolumeManager.cs
+++ b/Library/DiscUtils.Lvm/LogicalVolumeManager.cs
@@ -84,7 +84,8 @@ namespace DiscUtils.Lvm
             var partition = volumeInfo.Partition;
             if (partition == null) return false;
             return partition.BiosType == BiosPartitionTypes.LinuxLvm ||
-                   partition.GuidType == GuidPartitionTypes.LinuxLvm;
+                   partition.GuidType == GuidPartitionTypes.LinuxLvm ||
+                   PhysicalVolume.TryOpen(partition, out _);
         }
 
         /// <summary>

--- a/Library/DiscUtils.Lvm/PhysicalVolume.cs
+++ b/Library/DiscUtils.Lvm/PhysicalVolume.cs
@@ -72,6 +72,14 @@ namespace DiscUtils.Lvm
             return true;
         }
 
+        public static bool CanOpen(PartitionInfo volumeInfo)
+        {
+            using (var content = volumeInfo.Open())
+            {
+                return SearchLabel(content, out _);
+            }
+        }
+
         private static bool SearchLabel(Stream content, out PhysicalVolumeLabel pvLabel)
         {
             pvLabel = null;


### PR DESCRIPTION
Currently the `VolumeManager` also reports lvm physical volumes as logical volumes if the partition has a wrong partition type.

```csharp
var logical = new VolumeManager(disk).GetLogicalVolumes();
//now logical contains each PV with a wrong partition type in addition to the logical volumes residing on those PV
```

This change unifies the behavior of LVM `LogicalVolumeManagerFactory.HandlesPhysicalVolume` and `LogicalVolumeManagerFactory.MapDisk`.

I've seen many LVM installation with the default partition type `Linux Filesystem` since the linux kernel doesn't care.