### PR TITLE
Handle encoding in VMDK files. Fixes issue #214

### DIFF
--- a/Library/DiscUtils.Vmdk/DescriptorFile.cs
+++ b/Library/DiscUtils.Vmdk/DescriptorFile.cs
@@ -29,6 +29,17 @@ using DiscUtils.Streams;
 
 namespace DiscUtils.Vmdk
 {
+
+    internal class DescriptorFileHasEncodingException: Exception
+    {
+        public string encoding { get; private set; }
+
+        public DescriptorFileHasEncodingException(string encoding)
+        {
+            this.encoding = encoding;
+        }
+    }
+
     internal class DescriptorFile
     {
         private const string HeaderVersion = "version";
@@ -64,13 +75,13 @@ namespace DiscUtils.Vmdk
             _header.Add(new DescriptorFileEntry(HeaderCreateType, string.Empty, DescriptorFileEntryType.Quoted));
         }
 
-        public DescriptorFile(Stream source)
+        public DescriptorFile(Stream source, string encoding = null)
         {
             _header = new List<DescriptorFileEntry>();
             Extents = new List<ExtentDescriptor>();
             _diskDataBase = new List<DescriptorFileEntry>();
 
-            Load(source);
+            Load(source, encoding);
         }
 
         public DiskAdapterType AdapterType
@@ -407,7 +418,7 @@ namespace DiscUtils.Vmdk
             _diskDataBase.Add(new DescriptorFileEntry(key, value, DescriptorFileEntryType.Quoted));
         }
 
-        private void Load(Stream source)
+        private void Load(Stream source, string encoding = null)
         {
             if (source.Length - source.Position > MaxSize)
             {
@@ -415,7 +426,15 @@ namespace DiscUtils.Vmdk
                     "Invalid VMDK descriptor file, more than {0} bytes in length", MaxSize));
             }
 
-            StreamReader reader = new StreamReader(source);
+            StreamReader reader;
+            if (encoding == null)
+            {
+                reader = new StreamReader(source);
+            } else
+            {
+                reader = new StreamReader(source, Encoding.GetEncoding(encoding));
+            }
+
             string line = reader.ReadLine();
             while (line != null)
             {
@@ -438,6 +457,10 @@ namespace DiscUtils.Vmdk
                     else
                     {
                         DescriptorFileEntry entry = DescriptorFileEntry.Parse(line);
+                        if (entry.Key == "encoding" && (encoding == null || (entry.Value != encoding))) 
+                        {
+                            throw new DescriptorFileHasEncodingException(entry.Value);
+                        }
                         if (entry.Key.StartsWith("ddb.", StringComparison.Ordinal))
                         {
                             _diskDataBase.Add(entry);

--- a/Library/DiscUtils.Vmdk/DiskImageFile.cs
+++ b/Library/DiscUtils.Vmdk/DiskImageFile.cs
@@ -988,8 +988,15 @@ namespace DiscUtils.Vmdk
             if (header.Length < Sizes.Sector ||
                 EndianUtilities.ToUInt32LittleEndian(header, 0) != HostedSparseExtentHeader.VmdkMagicNumber)
             {
-                s.Position = 0;
-                _descriptor = new DescriptorFile(s);
+                try
+                {
+                    s.Position = 0;
+                    _descriptor = new DescriptorFile(s);
+                } catch (DescriptorFileHasEncodingException e)
+                {
+                    s.Position = 0;
+                    _descriptor = new DescriptorFile(s, e.encoding);
+                }
                 if (_access != FileAccess.Read)
                 {
                     _descriptor.ContentId = (uint)_rng.Next();
@@ -1006,7 +1013,14 @@ namespace DiscUtils.Vmdk
                 {
                     Stream descriptorStream = new SubStream(s, hdr.DescriptorOffset * Sizes.Sector,
                         hdr.DescriptorSize * Sizes.Sector);
-                    _descriptor = new DescriptorFile(descriptorStream);
+                    try
+                    {
+                        _descriptor = new DescriptorFile(descriptorStream);
+                    } catch (DescriptorFileHasEncodingException e)
+                    {
+                        descriptorStream.Seek(0, SeekOrigin.Begin);
+                        _descriptor = new DescriptorFile(descriptorStream, e.encoding);
+                    }
                     if (_access != FileAccess.Read)
                     {
                         _descriptor.ContentId = (uint)_rng.Next();


### PR DESCRIPTION
Currently, the encoding key in a VMDK descriptor is ignored. This causes problems when filenames of a split VMDK file use non-UTF8 encodings. This pull request detects an `encoding` key in a VMDK descriptor, and re-reads the descriptor using the correct encoding.