### PR TITLE
Fix xunit warnings

### DIFF
--- a/Tests/LibraryTests/Btrfs/SampleDataTests.cs
+++ b/Tests/LibraryTests/Btrfs/SampleDataTests.cs
@@ -26,11 +26,11 @@ namespace LibraryTests.Btrfs
             {
                 var manager = new VolumeManager(disk);
                 var logicalVolumes = manager.GetLogicalVolumes();
-                Assert.Equal(1, logicalVolumes.Length);
+                Assert.Single(logicalVolumes);
 
                 var volume = logicalVolumes[0];
                 var filesystems = FileSystemManager.DetectFileSystems(volume);
-                Assert.Equal(1, filesystems.Length);
+                Assert.Single(filesystems);
 
                 var filesystem = filesystems[0];
                 Assert.Equal("btrfs", filesystem.Name);
@@ -44,7 +44,7 @@ namespace LibraryTests.Btrfs
                     Assert.Equal(98304, btrfs.UsedSpace);
 
                     var subvolumes = ((BtrfsFileSystem)btrfs).GetSubvolumes();
-                    Assert.Equal(1, subvolumes.Length);
+                    Assert.Single(subvolumes);
                     Assert.Equal(256UL, subvolumes[0].Id);
                     Assert.Equal("subvolume", subvolumes[0].Name);
 

--- a/Tests/LibraryTests/Buffers/BufferTest.cs
+++ b/Tests/LibraryTests/Buffers/BufferTest.cs
@@ -37,12 +37,12 @@ namespace LibraryTests.Buffers
             memoryBuffer.Write(0, buffer, 0, 20);
             Assert.Equal(2, memoryBuffer.AllocatedChunks.Count());
             memoryBuffer.Clear(0, 20);
-            Assert.Equal(0, memoryBuffer.AllocatedChunks.Count());
+            Assert.Empty(memoryBuffer.AllocatedChunks);
 
             memoryBuffer.Write(0, buffer, 0, 15);
             Assert.Equal(2, memoryBuffer.AllocatedChunks.Count());
             memoryBuffer.Clear(0, 15);
-            Assert.Equal(1, memoryBuffer.AllocatedChunks.Count());
+            Assert.Single(memoryBuffer.AllocatedChunks);
         }
     }
 }

--- a/Tests/LibraryTests/DiscFileSystemDirectoryTest.cs
+++ b/Tests/LibraryTests/DiscFileSystemDirectoryTest.cs
@@ -371,7 +371,7 @@ namespace LibraryTests
 
         [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
-        public void Equals(NewFileSystemDelegate fsFactory)
+        public void DirectoryInfo_Equals(NewFileSystemDelegate fsFactory)
         {
             DiscFileSystem fs = fsFactory();
 

--- a/Tests/LibraryTests/DiscFileSystemDirectoryTest.cs
+++ b/Tests/LibraryTests/DiscFileSystemDirectoryTest.cs
@@ -38,7 +38,7 @@ namespace LibraryTests
             DiscDirectoryInfo dirInfo = fs.GetDirectoryInfo("SOMEDIR");
             dirInfo.Create();
 
-            Assert.Equal(1, fs.Root.GetDirectories().Length);
+            Assert.Single(fs.Root.GetDirectories());
         }
 
         [Theory]
@@ -50,8 +50,8 @@ namespace LibraryTests
             DiscDirectoryInfo dirInfo = fs.GetDirectoryInfo(@"SOMEDIR\CHILDDIR");
             dirInfo.Create();
 
-            Assert.Equal(1, fs.Root.GetDirectories().Length);
-            Assert.Equal(1, fs.GetDirectoryInfo(@"SOMEDIR").GetDirectories().Length);
+            Assert.Single(fs.Root.GetDirectories());
+            Assert.Single(fs.GetDirectoryInfo(@"SOMEDIR").GetDirectories());
             Assert.Equal("CHILDDIR", fs.GetDirectoryInfo(@"SOMEDIR").GetDirectories()[0].Name);
         }
 
@@ -65,9 +65,10 @@ namespace LibraryTests
             dirInfo.Create();
             dirInfo.Create();
 
-            Assert.Equal(1, fs.Root.GetDirectories().Length);
+            Assert.Single(fs.Root.GetDirectories());
         }
 
+        [Theory]
         [Trait("Category", "ThrowsException")]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void CreateInvalid_Long(NewFileSystemDelegate fsFactory)
@@ -78,6 +79,7 @@ namespace LibraryTests
             Assert.Throws<IOException>(() => dirInfo.Create());
         }
 
+        [Theory]
         [Trait("Category", "ThrowsException")]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void CreateInvalid_Characters(NewFileSystemDelegate fsFactory)
@@ -88,6 +90,7 @@ namespace LibraryTests
             Assert.Throws<IOException>(() => dirInfo.Create());
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Exists(NewFileSystemDelegate fsFactory)
         {
@@ -104,6 +107,7 @@ namespace LibraryTests
             Assert.False(fs.GetDirectoryInfo(@"SOMEDIR\NONDIR").Exists);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void FullName(NewFileSystemDelegate fsFactory)
         {
@@ -114,30 +118,33 @@ namespace LibraryTests
             Assert.Equal(@"SOMEDIR\CHILDDIR\", fs.GetDirectoryInfo(@"SOMEDIR\CHILDDIR").FullName);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Delete(NewFileSystemDelegate fsFactory)
         {
             DiscFileSystem fs = fsFactory();
 
             fs.CreateDirectory(@"Fred");
-            Assert.Equal(1, fs.Root.GetDirectories().Length);
+            Assert.Single(fs.Root.GetDirectories());
 
             fs.Root.GetDirectories(@"Fred")[0].Delete();
-            Assert.Equal(0, fs.Root.GetDirectories().Length);
+            Assert.Empty(fs.Root.GetDirectories());
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void DeleteRecursive(NewFileSystemDelegate fsFactory)
         {
             DiscFileSystem fs = fsFactory();
 
             fs.CreateDirectory(@"Fred\child");
-            Assert.Equal(1, fs.Root.GetDirectories().Length);
+            Assert.Single(fs.Root.GetDirectories());
 
             fs.Root.GetDirectories(@"Fred")[0].Delete(true);
-            Assert.Equal(0, fs.Root.GetDirectories().Length);
+            Assert.Empty(fs.Root.GetDirectories());
         }
 
+        [Theory]
         [Trait("Category", "ThrowsException")]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void DeleteRoot(NewFileSystemDelegate fsFactory)
@@ -147,6 +154,7 @@ namespace LibraryTests
             Assert.Throws<IOException>(() => fs.Root.Delete());
         }
 
+        [Theory]
         [Trait("Category", "ThrowsException")]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void DeleteNonEmpty_NonRecursive(NewFileSystemDelegate fsFactory)
@@ -157,6 +165,7 @@ namespace LibraryTests
             Assert.Throws<IOException>(() => fs.Root.GetDirectories(@"Fred")[0].Delete());
         }
 
+        [Theory]
         [Trait("Category", "SlowTest")]
         [MemberData(nameof(FileSystemSource.QuickReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void CreateDeleteLeakTest(NewFileSystemDelegate fsFactory)
@@ -180,6 +189,7 @@ namespace LibraryTests
             }
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Move(NewFileSystemDelegate fsFactory)
         {
@@ -189,9 +199,10 @@ namespace LibraryTests
             fs.GetDirectoryInfo(@"SOMEDIR\CHILD").MoveTo("NEWDIR");
 
             Assert.Equal(2, fs.Root.GetDirectories().Length);
-            Assert.Equal(0, fs.Root.GetDirectories("SOMEDIR")[0].GetDirectories().Length);
+            Assert.Empty(fs.Root.GetDirectories("SOMEDIR")[0].GetDirectories());
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Extension(NewFileSystemDelegate fsFactory)
         {
@@ -201,6 +212,7 @@ namespace LibraryTests
             Assert.Equal("", fs.GetDirectoryInfo("fred").Extension);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void GetDirectories(NewFileSystemDelegate fsFactory)
         {
@@ -212,23 +224,24 @@ namespace LibraryTests
             Assert.Equal(2, fs.Root.GetDirectories().Length);
 
             DiscDirectoryInfo someDir = fs.Root.GetDirectories(@"SoMeDir")[0];
-            Assert.Equal(1, fs.Root.GetDirectories("SOMEDIR").Length);
+            Assert.Single(fs.Root.GetDirectories("SOMEDIR"));
             Assert.Equal("SOMEDIR", someDir.Name);
 
-            Assert.Equal(1, someDir.GetDirectories("*.*").Length);
+            Assert.Single(someDir.GetDirectories("*.*"));
             Assert.Equal("CHILD", someDir.GetDirectories("*.*")[0].Name);
             Assert.Equal(2, someDir.GetDirectories("*.*", SearchOption.AllDirectories).Length);
 
             Assert.Equal(4, fs.Root.GetDirectories("*.*", SearchOption.AllDirectories).Length);
             Assert.Equal(2, fs.Root.GetDirectories("*.*", SearchOption.TopDirectoryOnly).Length);
 
-            Assert.Equal(1, fs.Root.GetDirectories("*.DIR", SearchOption.AllDirectories).Length);
+            Assert.Single(fs.Root.GetDirectories("*.DIR", SearchOption.AllDirectories));
             Assert.Equal(@"A.DIR\", fs.Root.GetDirectories("*.DIR", SearchOption.AllDirectories)[0].FullName);
 
-            Assert.Equal(1, fs.Root.GetDirectories("GCHILD", SearchOption.AllDirectories).Length);
+            Assert.Single(fs.Root.GetDirectories("GCHILD", SearchOption.AllDirectories));
             Assert.Equal(@"SOMEDIR\CHILD\GCHILD\", fs.Root.GetDirectories("GCHILD", SearchOption.AllDirectories)[0].FullName);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void GetDirectories_BadPath(NewFileSystemDelegate fsFactory)
         {
@@ -237,6 +250,7 @@ namespace LibraryTests
             Assert.Throws<DirectoryNotFoundException>(() => fs.GetDirectories(@"\baddir"));
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void GetFiles(NewFileSystemDelegate fsFactory)
         {
@@ -249,15 +263,16 @@ namespace LibraryTests
             using (Stream s = fs.OpenFile(@"SOMEDIR\FOO.TXT", FileMode.Create)) { }
             using (Stream s = fs.OpenFile(@"SOMEDIR\CHILD\GCHILD\BAR.TXT", FileMode.Create)) { }
 
-            Assert.Equal(1, fs.Root.GetFiles().Length);
+            Assert.Single(fs.Root.GetFiles());
             Assert.Equal("FOO.TXT", fs.Root.GetFiles()[0].FullName);
 
             Assert.Equal(2, fs.Root.GetDirectories("SOMEDIR")[0].GetFiles("*.TXT").Length);
             Assert.Equal(4, fs.Root.GetFiles("*.TXT", SearchOption.AllDirectories).Length);
 
-            Assert.Equal(0, fs.Root.GetFiles("*.DIR", SearchOption.AllDirectories).Length);
+            Assert.Empty(fs.Root.GetFiles("*.DIR", SearchOption.AllDirectories));
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void GetFileSystemInfos(NewFileSystemDelegate fsFactory)
         {
@@ -272,10 +287,11 @@ namespace LibraryTests
 
             Assert.Equal(3, fs.Root.GetFileSystemInfos().Length);
 
-            Assert.Equal(1, fs.Root.GetFileSystemInfos("*.EXT").Length);
+            Assert.Single(fs.Root.GetFileSystemInfos("*.EXT"));
             Assert.Equal(2, fs.Root.GetFileSystemInfos("*.?XT").Length);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Parent(NewFileSystemDelegate fsFactory)
         {
@@ -286,6 +302,7 @@ namespace LibraryTests
             Assert.Equal(fs.Root, fs.Root.GetDirectories("SOMEDIR")[0].Parent);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Parent_Root(NewFileSystemDelegate fsFactory)
         {
@@ -294,6 +311,7 @@ namespace LibraryTests
             Assert.Null(fs.Root.Parent);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void CreationTimeUtc(NewFileSystemDelegate fsFactory)
         {
@@ -305,6 +323,7 @@ namespace LibraryTests
             Assert.True(DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(10)) <= fs.Root.GetDirectories("DIR")[0].CreationTimeUtc);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void CreationTime(NewFileSystemDelegate fsFactory)
         {
@@ -316,6 +335,7 @@ namespace LibraryTests
             Assert.True(DateTime.Now.Subtract(TimeSpan.FromSeconds(10)) <= fs.Root.GetDirectories("DIR")[0].CreationTime);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void LastAccessTime(NewFileSystemDelegate fsFactory)
         {
@@ -332,6 +352,7 @@ namespace LibraryTests
             Assert.True(baseTime < di.LastAccessTime);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void LastWriteTime(NewFileSystemDelegate fsFactory)
         {
@@ -348,6 +369,7 @@ namespace LibraryTests
             Assert.True(baseTime < di.LastWriteTime);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Equals(NewFileSystemDelegate fsFactory)
         {
@@ -356,6 +378,7 @@ namespace LibraryTests
             Assert.Equal(fs.GetDirectoryInfo("foo"), fs.GetDirectoryInfo("foo"));
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void RootBehaviour(NewFileSystemDelegate fsFactory)
         {

--- a/Tests/LibraryTests/DiscFileSystemFileTest.cs
+++ b/Tests/LibraryTests/DiscFileSystemFileTest.cs
@@ -29,6 +29,7 @@ namespace LibraryTests
 {
     public class DiscFileSystemFileTest
     {
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void CreateFile(NewFileSystemDelegate fsFactory)
         {
@@ -51,6 +52,7 @@ namespace LibraryTests
             }
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         [Trait("Category", "ThrowsException")]
         public void CreateFileInvalid_Long(NewFileSystemDelegate fsFactory)
@@ -66,6 +68,7 @@ namespace LibraryTests
             });
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         [Trait("Category", "ThrowsException")]
         public void CreateFileInvalid_Characters(NewFileSystemDelegate fsFactory)
@@ -81,6 +84,7 @@ namespace LibraryTests
             });
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void DeleteFile(NewFileSystemDelegate fsFactory)
         {
@@ -88,15 +92,16 @@ namespace LibraryTests
 
             using (Stream s = fs.GetFileInfo("foo.txt").Open(FileMode.Create, FileAccess.ReadWrite)) { }
 
-            Assert.Equal(1, fs.Root.GetFiles().Length);
+            Assert.Single(fs.Root.GetFiles());
 
             DiscFileInfo fi = fs.GetFileInfo("foo.txt");
 
             fi.Delete();
 
-            Assert.Equal(0, fs.Root.GetFiles().Length);
+            Assert.Empty(fs.Root.GetFiles());
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Length(NewFileSystemDelegate fsFactory)
         {
@@ -156,6 +161,7 @@ namespace LibraryTests
             }
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         [Trait("Category", "ThrowsException")]
         public void Open_FileNotFound(NewFileSystemDelegate fsFactory)
@@ -173,6 +179,7 @@ namespace LibraryTests
             });
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         [Trait("Category", "ThrowsException")]
         public void Open_FileExists(NewFileSystemDelegate fsFactory)
@@ -192,6 +199,7 @@ namespace LibraryTests
 
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         [Trait("Category", "ThrowsException")]
         public void Open_DirExists(NewFileSystemDelegate fsFactory)
@@ -204,6 +212,7 @@ namespace LibraryTests
             Assert.Throws<IOException>(() => di.Open(FileMode.Create));
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Open_Read(NewFileSystemDelegate fsFactory)
         {
@@ -225,6 +234,7 @@ namespace LibraryTests
             }
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         [Trait("Category", "ThrowsException")]
         public void Open_Read_Fail(NewFileSystemDelegate fsFactory)
@@ -238,6 +248,7 @@ namespace LibraryTests
             }
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Open_Write(NewFileSystemDelegate fsFactory)
         {
@@ -252,6 +263,7 @@ namespace LibraryTests
             }
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         [Trait("Category", "ThrowsException")]
         public void Open_Write_Fail(NewFileSystemDelegate fsFactory)
@@ -273,6 +285,7 @@ namespace LibraryTests
             }
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Name(NewFileSystemDelegate fsFactory)
         {
@@ -283,6 +296,7 @@ namespace LibraryTests
             Assert.Equal("foo.txt", fs.GetFileInfo(@"\foo.txt").Name);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Attributes(NewFileSystemDelegate fsFactory)
         {
@@ -303,6 +317,7 @@ namespace LibraryTests
             Assert.Equal(newAttrs, fs.GetFileInfo("foo.txt").Attributes);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         [Trait("Category", "ThrowsException")]
         public void Attributes_ChangeType(NewFileSystemDelegate fsFactory)
@@ -315,6 +330,7 @@ namespace LibraryTests
             Assert.Throws<ArgumentException>(() => fi.Attributes = fi.Attributes | FileAttributes.Directory);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Exists(NewFileSystemDelegate fsFactory)
         {
@@ -331,6 +347,7 @@ namespace LibraryTests
             Assert.False(fs.GetFileInfo("dir.txt").Exists);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void CreationTimeUtc(NewFileSystemDelegate fsFactory)
         {
@@ -342,6 +359,7 @@ namespace LibraryTests
             Assert.True(DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(10)) <= fs.GetFileInfo("foo.txt").CreationTimeUtc);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void CreationTime(NewFileSystemDelegate fsFactory)
         {
@@ -353,6 +371,7 @@ namespace LibraryTests
             Assert.True(DateTime.Now.Subtract(TimeSpan.FromSeconds(10)) <= fs.GetFileInfo("foo.txt").CreationTime);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void LastAccessTime(NewFileSystemDelegate fsFactory)
         {
@@ -369,6 +388,7 @@ namespace LibraryTests
             Assert.True(baseTime < fi.LastAccessTime);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void LastWriteTime(NewFileSystemDelegate fsFactory)
         {
@@ -385,6 +405,7 @@ namespace LibraryTests
             Assert.True(baseTime < fi.LastWriteTime);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Delete(NewFileSystemDelegate fsFactory)
         {
@@ -396,6 +417,7 @@ namespace LibraryTests
             Assert.False(fs.FileExists("foo.txt"));
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         [Trait("Category", "ThrowsException")]
         public void Delete_Dir(NewFileSystemDelegate fsFactory)
@@ -407,6 +429,7 @@ namespace LibraryTests
             Assert.Throws<FileNotFoundException>(() => fs.GetFileInfo("foo.txt").Delete());
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         [Trait("Category", "ThrowsException")]
         public void Delete_NoFile(NewFileSystemDelegate fsFactory)
@@ -416,6 +439,7 @@ namespace LibraryTests
             Assert.Throws<FileNotFoundException>(() => fs.GetFileInfo("foo.txt").Delete());
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void CopyFile(NewFileSystemDelegate fsFactory)
         {
@@ -451,7 +475,7 @@ namespace LibraryTests
             Assert.True(fi.Exists);
         }
 
-
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void MoveFile(NewFileSystemDelegate fsFactory)
         {
@@ -479,6 +503,7 @@ namespace LibraryTests
             Assert.False(fi.Exists);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void MoveFile_Overwrite(NewFileSystemDelegate fsFactory)
         {
@@ -502,6 +527,7 @@ namespace LibraryTests
             Assert.Equal(1, fi2.Length);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Equals(NewFileSystemDelegate fsFactory)
         {
@@ -510,6 +536,7 @@ namespace LibraryTests
             Assert.Equal(fs.GetFileInfo("foo.txt"), fs.GetFileInfo("foo.txt"));
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void Parent(NewFileSystemDelegate fsFactory)
         {
@@ -523,6 +550,7 @@ namespace LibraryTests
             Assert.Equal(fs.GetDirectoryInfo(@"SOMEDIR\ADIR"), fi.Directory);
         }
 
+        [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
         public void VolumeLabel(NewFileSystemDelegate fsFactory)
         {

--- a/Tests/LibraryTests/DiscFileSystemFileTest.cs
+++ b/Tests/LibraryTests/DiscFileSystemFileTest.cs
@@ -529,7 +529,7 @@ namespace LibraryTests
 
         [Theory]
         [MemberData(nameof(FileSystemSource.ReadWriteFileSystems), MemberType = typeof(FileSystemSource))]
-        public void Equals(NewFileSystemDelegate fsFactory)
+        public void FileInfo_Equals(NewFileSystemDelegate fsFactory)
         {
             DiscFileSystem fs = fsFactory();
 

--- a/Tests/LibraryTests/Fat/FatFileSystemTest.cs
+++ b/Tests/LibraryTests/Fat/FatFileSystemTest.cs
@@ -63,7 +63,7 @@ namespace LibraryTests.Fat
                 fs.CreateDirectory(name);
 
                 string[] dirs = fs.GetDirectories("");
-                Assert.Equal(1, dirs.Length);
+                Assert.Single(dirs);
                 Assert.Equal(upperDE, dirs[0]); // Uppercase
 
                 Assert.True(fs.DirectoryExists(lowerDE));
@@ -73,7 +73,7 @@ namespace LibraryTests.Fat
                 Assert.Equal(2, fs.GetDirectories("").Length);
 
                 fs.DeleteDirectory(lowerDE + lowerDE + lowerDE);
-                Assert.Equal(1, fs.GetDirectories("").Length);
+                Assert.Single(fs.GetDirectories(""));
             }
 
             FileSystemInfo[] detectDefaultFileSystems = FileSystemManager.DetectFileSystems(ms);
@@ -84,7 +84,7 @@ namespace LibraryTests.Fat
 
             Assert.True(fs2.DirectoryExists(lowerDE));
             Assert.True(fs2.DirectoryExists(upperDE));
-            Assert.Equal(1, fs2.GetDirectories("").Length);
+            Assert.Single(fs2.GetDirectories(""));
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace LibraryTests.Fat
             fs.CreateDirectory(name);
 
             string[] dirs = fs.GetDirectories("");
-            Assert.Equal(1, dirs.Length);
+            Assert.Single(dirs);
             Assert.Equal(graphicChar, dirs[0]); // Uppercase
 
             Assert.True(fs.DirectoryExists(graphicChar));
@@ -117,7 +117,7 @@ namespace LibraryTests.Fat
             fs.CreateDirectory(@"DIRB\DIRC");
 
             FatFileSystem fs2 = new FatFileSystem(ms);
-            Assert.Equal(1, fs2.Root.GetDirectories().Length);
+            Assert.Single(fs2.Root.GetDirectories());
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace LibraryTests.Fat
         public void CanWrite()
         {
             FatFileSystem fs = FatFileSystem.FormatFloppy(new MemoryStream(), FloppyDiskType.HighDensity, "FLOPPY_IMG ");
-            Assert.Equal(true, fs.CanWrite);
+            Assert.True(fs.CanWrite);
         }
 
         [Fact]

--- a/Tests/LibraryTests/FileSystemManagerTest.cs
+++ b/Tests/LibraryTests/FileSystemManagerTest.cs
@@ -32,10 +32,10 @@ namespace LibraryTests
         public void Detect()
         {
             MemoryStream shortStream = new MemoryStream(new byte[5]);
-            Assert.Equal(0, FileSystemManager.DetectFileSystems(shortStream).Length);
+            Assert.Empty(FileSystemManager.DetectFileSystems(shortStream));
 
             MemoryStream longStream = new MemoryStream(new byte[100000]);
-            Assert.Equal(0, FileSystemManager.DetectFileSystems(longStream).Length);
+            Assert.Empty(FileSystemManager.DetectFileSystems(longStream));
         }
     }
 }

--- a/Tests/LibraryTests/Iso9660/IsoDirectoryInfoTest.cs
+++ b/Tests/LibraryTests/Iso9660/IsoDirectoryInfoTest.cs
@@ -89,20 +89,20 @@ namespace LibraryTests.Iso9660
             Assert.Equal(2, fs.Root.GetDirectories().Length);
 
             DiscDirectoryInfo someDir = fs.Root.GetDirectories(@"SoMeDir")[0];
-            Assert.Equal(1, fs.Root.GetDirectories("SOMEDIR").Length);
+            Assert.Single(fs.Root.GetDirectories("SOMEDIR"));
             Assert.Equal("SOMEDIR", someDir.Name);
 
-            Assert.Equal(1, someDir.GetDirectories("*.*").Length);
+            Assert.Single(someDir.GetDirectories("*.*"));
             Assert.Equal("CHILD", someDir.GetDirectories("*.*")[0].Name);
             Assert.Equal(2, someDir.GetDirectories("*.*", SearchOption.AllDirectories).Length);
 
             Assert.Equal(4, fs.Root.GetDirectories("*.*", SearchOption.AllDirectories).Length);
             Assert.Equal(2, fs.Root.GetDirectories("*.*", SearchOption.TopDirectoryOnly).Length);
 
-            Assert.Equal(1, fs.Root.GetDirectories("*.DIR", SearchOption.AllDirectories).Length);
+            Assert.Single(fs.Root.GetDirectories("*.DIR", SearchOption.AllDirectories));
             Assert.Equal(@"A.DIR\", fs.Root.GetDirectories("*.DIR", SearchOption.AllDirectories)[0].FullName);
 
-            Assert.Equal(1, fs.Root.GetDirectories("GCHILD", SearchOption.AllDirectories).Length);
+            Assert.Single(fs.Root.GetDirectories("GCHILD", SearchOption.AllDirectories));
             Assert.Equal(@"SOMEDIR\CHILD\GCHILD\", fs.Root.GetDirectories("GCHILD", SearchOption.AllDirectories)[0].FullName);
         }
 
@@ -118,13 +118,13 @@ namespace LibraryTests.Iso9660
             builder.AddFile(@"SOMEDIR\CHILD\GCHILD\BAR.TXT", new byte[10]);
             CDReader fs = new CDReader(builder.Build(), false);
 
-            Assert.Equal(1, fs.Root.GetFiles().Length);
+            Assert.Single(fs.Root.GetFiles());
             Assert.Equal("FOO.TXT", fs.Root.GetFiles()[0].FullName);
 
             Assert.Equal(2, fs.Root.GetDirectories("SOMEDIR")[0].GetFiles("*.TXT").Length);
             Assert.Equal(4, fs.Root.GetFiles("*.TXT", SearchOption.AllDirectories).Length);
 
-            Assert.Equal(0, fs.Root.GetFiles("*.DIR", SearchOption.AllDirectories).Length);
+            Assert.Empty(fs.Root.GetFiles("*.DIR", SearchOption.AllDirectories));
         }
 
         [Fact]
@@ -141,7 +141,7 @@ namespace LibraryTests.Iso9660
 
             Assert.Equal(3, fs.Root.GetFileSystemInfos().Length);
 
-            Assert.Equal(1, fs.Root.GetFileSystemInfos("*.EXT").Length);
+            Assert.Single(fs.Root.GetFileSystemInfos("*.EXT"));
             Assert.Equal(2, fs.Root.GetFileSystemInfos("*.?XT").Length);
         }
 

--- a/Tests/LibraryTests/Iso9660/SampleDataTests.cs
+++ b/Tests/LibraryTests/Iso9660/SampleDataTests.cs
@@ -20,7 +20,7 @@ namespace LibraryTests.Iso9660
                 Assert.Equal("sub-directory", dir.Name);
 
                 DiscFileInfo[] file = dir.GetFiles("apple-test.txt");
-                Assert.Equal(1, file.Length);
+                Assert.Single(file);
                 Assert.Equal(21, file[0].Length);
                 Assert.Equal("apple-test.txt", file[0].Name);
                 Assert.Equal(dir, file[0].Directory);

--- a/Tests/LibraryTests/Ntfs/NtfsFileSystemTest.cs
+++ b/Tests/LibraryTests/Ntfs/NtfsFileSystemTest.cs
@@ -65,7 +65,7 @@ namespace LibraryTests.Ntfs
 
             Assert.Equal(12345, rp.Tag);
             Assert.NotNull(rp.Content);
-            Assert.Equal(0, rp.Content.Length);
+            Assert.Empty(rp.Content);
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace LibraryTests.Ntfs
             }
 
             var ranges = ntfs.PathToClusters("file");
-            Assert.Equal(1, ranges.Length);
+            Assert.Single(ranges);
             Assert.Equal(1, ranges[0].Count);
 
 
@@ -127,7 +127,7 @@ namespace LibraryTests.Ntfs
                 s.WriteByte(1);
             }
             ranges = ntfs.PathToClusters("file2");
-            Assert.Equal(0, ranges.Length);
+            Assert.Empty(ranges);
         }
 
         [Fact]
@@ -149,7 +149,7 @@ namespace LibraryTests.Ntfs
                 }
 
                 var extents = ntfs.PathToExtents("file");
-                Assert.Equal(1, extents.Length);
+                Assert.Single(extents);
                 Assert.Equal(ntfs.ClusterSize, extents[0].Length);
 
                 ms.Position = extents[0].Start;
@@ -166,7 +166,7 @@ namespace LibraryTests.Ntfs
                     s.WriteByte(0x2C);
                 }
                 extents = ntfs.PathToExtents("file2");
-                Assert.Equal(1, extents.Length);
+                Assert.Single(extents);
                 Assert.Equal(3, extents[0].Length);
 
                 byte[] read = new byte[100];
@@ -210,11 +210,11 @@ namespace LibraryTests.Ntfs
                 ntfs.DeleteFile("hl" + i);
             }
 
-            Assert.Equal(1, ntfs.GetFiles(@"\").Length);
+            Assert.Single(ntfs.GetFiles(@"\"));
 
             ntfs.DeleteFile("file");
 
-            Assert.Equal(0, ntfs.GetFiles(@"\").Length);
+            Assert.Empty(ntfs.GetFiles(@"\"));
         }
 
         [Fact]
@@ -323,10 +323,10 @@ namespace LibraryTests.Ntfs
             NtfsFileSystem ntfs = FileSystemSource.NtfsFileSystem();
 
             ntfs.OpenFile("AFILE.TXT", FileMode.Create).Dispose();
-            Assert.Equal(0, ntfs.GetAlternateDataStreams("AFILE.TXT").Length);
+            Assert.Empty(ntfs.GetAlternateDataStreams("AFILE.TXT"));
 
             ntfs.OpenFile("AFILE.TXT:ALTSTREAM", FileMode.Create).Dispose();
-            Assert.Equal(1, ntfs.GetAlternateDataStreams("AFILE.TXT").Length);
+            Assert.Single(ntfs.GetAlternateDataStreams("AFILE.TXT"));
             Assert.Equal("ALTSTREAM", ntfs.GetAlternateDataStreams("AFILE.TXT")[0]);
         }
 
@@ -337,11 +337,11 @@ namespace LibraryTests.Ntfs
 
             ntfs.OpenFile("AFILE.TXT", FileMode.Create).Dispose();
             ntfs.OpenFile("AFILE.TXT:ALTSTREAM", FileMode.Create).Dispose();
-            Assert.Equal(1, ntfs.GetAlternateDataStreams("AFILE.TXT").Length);
+            Assert.Single(ntfs.GetAlternateDataStreams("AFILE.TXT"));
 
             ntfs.DeleteFile("AFILE.TXT:ALTSTREAM");
-            Assert.Equal(1, ntfs.GetFileSystemEntries("").Length);
-            Assert.Equal(0, ntfs.GetAlternateDataStreams("AFILE.TXT").Length);
+            Assert.Single(ntfs.GetFileSystemEntries(""));
+            Assert.Empty(ntfs.GetAlternateDataStreams("AFILE.TXT"));
         }
 
         [Fact]

--- a/Tests/LibraryTests/SquashFs/SquashFileSystemBuilderTest.cs
+++ b/Tests/LibraryTests/SquashFs/SquashFileSystemBuilderTest.cs
@@ -39,7 +39,7 @@ namespace LibraryTests.SquashFs
             builder.Build(fsImage);
 
             SquashFileSystemReader reader = new SquashFileSystemReader(fsImage);
-            Assert.Equal(1, reader.GetFileSystemEntries("\\").Length);
+            Assert.Single(reader.GetFileSystemEntries("\\"));
             Assert.Equal(4, reader.GetFileLength("file"));
             Assert.True(reader.FileExists("file"));
             Assert.False(reader.DirectoryExists("file"));

--- a/Tests/LibraryTests/StreamExtentTest.cs
+++ b/Tests/LibraryTests/StreamExtentTest.cs
@@ -195,7 +195,7 @@ namespace LibraryTests
 
             List<Range<long,long>> ranges = new List<Range<long,long>>(StreamExtent.Blocks(s, 10));
 
-            Assert.Equal(1, ranges.Count);
+            Assert.Single(ranges);
             Assert.Equal(0, ranges[0].Offset);
             Assert.Equal(2, ranges[0].Count);
 
@@ -206,7 +206,7 @@ namespace LibraryTests
 
             ranges = new List<Range<long, long>>(StreamExtent.Blocks(s, 10));
 
-            Assert.Equal(1, ranges.Count);
+            Assert.Single(ranges);
             Assert.Equal(0, ranges[0].Offset);
             Assert.Equal(2, ranges[0].Count);
 
@@ -226,7 +226,7 @@ namespace LibraryTests
         }
 
 
-        public void Compare(IEnumerable<StreamExtent> expected, IEnumerable<StreamExtent> actual)
+        private void Compare(IEnumerable<StreamExtent> expected, IEnumerable<StreamExtent> actual)
         {
             List<StreamExtent> eList = new List<StreamExtent>(expected);
             List<StreamExtent> aList = new List<StreamExtent>(actual);

--- a/Tests/LibraryTests/Swap/SampleDataTests.cs
+++ b/Tests/LibraryTests/Swap/SampleDataTests.cs
@@ -23,11 +23,11 @@ namespace LibraryTests.Swap
             {
                 var manager = new VolumeManager(disk);
                 var logicalVolumes = manager.GetLogicalVolumes();
-                Assert.Equal(1, logicalVolumes.Length);
+                Assert.Single(logicalVolumes);
 
                 var volume = logicalVolumes[0];
                 var filesystems = FileSystemManager.DetectFileSystems(volume);
-                Assert.Equal(1, filesystems.Length);
+                Assert.Single(filesystems);
 
                 var filesystem = filesystems[0];
                 Assert.Equal("Swap", filesystem.Name);

--- a/Tests/LibraryTests/ThreadSafeStreamTest.cs
+++ b/Tests/LibraryTests/ThreadSafeStreamTest.cs
@@ -98,12 +98,12 @@ namespace LibraryTests
             tss.WriteByte(99);
 
             List<StreamExtent> extents = new List<StreamExtent>(altView.Extents);
-            Assert.Equal(1, extents.Count);
+            Assert.Single(extents);
             Assert.Equal(100, extents[0].Start);
             Assert.Equal(1, extents[0].Length);
 
             extents = new List<StreamExtent>(altView.GetExtentsInRange(10, 300));
-            Assert.Equal(1, extents.Count);
+            Assert.Single(extents);
             Assert.Equal(100, extents[0].Start);
             Assert.Equal(1, extents[0].Length);
         }
@@ -169,11 +169,11 @@ namespace LibraryTests
         {
             SparseMemoryStream memStream = new SparseMemoryStream(new SparseMemoryBuffer(1), FileAccess.ReadWrite);
             ThreadSafeStream tss = new ThreadSafeStream(memStream);
-            Assert.Equal(true, tss.CanWrite);
+            Assert.True(tss.CanWrite);
 
             memStream = new SparseMemoryStream(new SparseMemoryBuffer(1), FileAccess.Read);
             tss = new ThreadSafeStream(memStream);
-            Assert.Equal(false, tss.CanWrite);
+            Assert.False(tss.CanWrite);
         }
 
         [Fact]
@@ -181,11 +181,11 @@ namespace LibraryTests
         {
             SparseMemoryStream memStream = new SparseMemoryStream(new SparseMemoryBuffer(1), FileAccess.ReadWrite);
             ThreadSafeStream tss = new ThreadSafeStream(memStream);
-            Assert.Equal(true, tss.CanRead);
+            Assert.True(tss.CanRead);
 
             memStream = new SparseMemoryStream(new SparseMemoryBuffer(1), FileAccess.Write);
             tss = new ThreadSafeStream(memStream);
-            Assert.Equal(false, tss.CanRead);
+            Assert.False(tss.CanRead);
         }
     }
 }

--- a/Tests/LibraryTests/Vhd/DiskBuilderTest.cs
+++ b/Tests/LibraryTests/Vhd/DiskBuilderTest.cs
@@ -57,7 +57,7 @@ namespace LibraryTests.Vhd
 
 
             DiskImageFileSpecification[] fileSpecs = builder.Build("foo");
-            Assert.Equal(1, fileSpecs.Length);
+            Assert.Single(fileSpecs);
             Assert.Equal("foo.vhd", fileSpecs[0].Name);
 
             using (Disk disk = new Disk(fileSpecs[0].OpenStream(), Ownership.Dispose))
@@ -82,7 +82,7 @@ namespace LibraryTests.Vhd
 
 
             DiskImageFileSpecification[] fileSpecs = builder.Build("foo");
-            Assert.Equal(1, fileSpecs.Length);
+            Assert.Single(fileSpecs);
             Assert.Equal("foo.vhd", fileSpecs[0].Name);
 
             using (Disk disk = new Disk(fileSpecs[0].OpenStream(), Ownership.Dispose))

--- a/Tests/LibraryTests/Vhd/DynamicStreamTest.cs
+++ b/Tests/LibraryTests/Vhd/DynamicStreamTest.cs
@@ -176,23 +176,23 @@ namespace LibraryTests.Vhd
 
                 // Starts before first extent, ends before end of extent
                 List<StreamExtent> extents = new List<StreamExtent>(disk.Content.GetExtentsInRange(0, 21 * 512));
-                Assert.Equal(1, extents.Count);
+                Assert.Single(extents);
                 Assert.Equal(20 * 512, extents[0].Start);
                 Assert.Equal(1 * 512, extents[0].Length);
 
                 // Limit to disk content length
                 extents = new List<StreamExtent>(disk.Content.GetExtentsInRange(21 * 512, 20 * 512));
-                Assert.Equal(1, extents.Count);
+                Assert.Single(extents);
                 Assert.Equal(21 * 512, extents[0].Start);
                 Assert.Equal(3 * 512, extents[0].Length);
 
                 // Out of range
                 extents = new List<StreamExtent>(disk.Content.GetExtentsInRange(25 * 512, 4 * 512));
-                Assert.Equal(0, extents.Count);
+                Assert.Empty(extents);
 
                 // Non-sector multiples
                 extents = new List<StreamExtent>(disk.Content.GetExtentsInRange(21 * 512 + 10, 20 * 512));
-                Assert.Equal(1, extents.Count);
+                Assert.Single(extents);
                 Assert.Equal(21 * 512 + 10, extents[0].Start);
                 Assert.Equal(3 * 512 - 10, extents[0].Length);
             }

--- a/Tests/LibraryTests/Vhdx/DiskBuilderTest.cs
+++ b/Tests/LibraryTests/Vhdx/DiskBuilderTest.cs
@@ -57,7 +57,7 @@ namespace LibraryTests.Vhdx
 
 
             DiskImageFileSpecification[] fileSpecs = builder.Build("foo");
-            Assert.Equal(1, fileSpecs.Length);
+            Assert.Single(fileSpecs);
             Assert.Equal("foo.vhdx", fileSpecs[0].Name);
 
             using (Disk disk = new Disk(fileSpecs[0].OpenStream(), Ownership.Dispose))
@@ -82,7 +82,7 @@ namespace LibraryTests.Vhdx
 
 
             DiskImageFileSpecification[] fileSpecs = builder.Build("foo");
-            Assert.Equal(1, fileSpecs.Length);
+            Assert.Single(fileSpecs);
             Assert.Equal("foo.vhdx", fileSpecs[0].Name);
 
             using (Disk disk = new Disk(fileSpecs[0].OpenStream(), Ownership.Dispose))
@@ -99,7 +99,7 @@ namespace LibraryTests.Vhdx
             builder.Content = diskContent;
 
             DiskImageFileSpecification[] fileSpecs = builder.Build("foo");
-            Assert.Equal(1, fileSpecs.Length);
+            Assert.Single(fileSpecs);
             Assert.Equal("foo.vhdx", fileSpecs[0].Name);
 
             using (Disk disk = new Disk(fileSpecs[0].OpenStream(), Ownership.Dispose))

--- a/Tests/LibraryTests/Vmdk/DiskTest.cs
+++ b/Tests/LibraryTests/Vmdk/DiskTest.cs
@@ -47,7 +47,7 @@ namespace LibraryTests.Vmdk
 
                 List<DiskImageFile> links = new List<DiskImageFile>(disk.Links);
                 List<string> paths = new List<string>(links[0].ExtentPaths);
-                Assert.Equal(1, paths.Count);
+                Assert.Single(paths);
                 Assert.Equal("a-flat.vmdk", paths[0]);
             }
         }
@@ -63,7 +63,7 @@ namespace LibraryTests.Vmdk
 
                 List<DiskImageFile> links = new List<DiskImageFile>(disk.Links);
                 List<string> paths = new List<string>(links[0].ExtentPaths);
-                Assert.Equal(1, paths.Count);
+                Assert.Single(paths);
                 Assert.Equal("a-flat.vmdk", paths[0]);
             }
         }
@@ -89,7 +89,7 @@ namespace LibraryTests.Vmdk
 
                 List<DiskImageFile> links = new List<DiskImageFile>(disk.Links);
                 List<string> paths = new List<string>(links[0].ExtentPaths);
-                Assert.Equal(1, paths.Count);
+                Assert.Single(paths);
                 Assert.Equal("a.vmdk", paths[0]);
             }
         }
@@ -111,7 +111,7 @@ namespace LibraryTests.Vmdk
                 Assert.Equal(2, links.Count);
 
                 List<string> paths = new List<string>(links[0].ExtentPaths);
-                Assert.Equal(1, paths.Count);
+                Assert.Single(paths);
                 Assert.Equal("diff.vmdk", paths[0]);
             }
             Assert.True(fs.GetFileLength(@"\diff\diff.vmdk") > 2 * 1024 * 1024);

--- a/Tests/LibraryTests/Vmdk/DynamicStreamTest.cs
+++ b/Tests/LibraryTests/Vmdk/DynamicStreamTest.cs
@@ -338,23 +338,23 @@ namespace LibraryTests.Vmdk
 
                 // Starts before first extent, ends before end of extent
                 List<StreamExtent> extents = new List<StreamExtent>(disk.Content.GetExtentsInRange(0, 21 * unit));
-                Assert.Equal(1, extents.Count);
+                Assert.Single(extents);
                 Assert.Equal(20 * unit, extents[0].Start);
                 Assert.Equal(1 * unit, extents[0].Length);
 
                 // Limit to disk content length
                 extents = new List<StreamExtent>(disk.Content.GetExtentsInRange(21 * unit, 20 * unit));
-                Assert.Equal(1, extents.Count);
+                Assert.Single(extents);
                 Assert.Equal(21 * unit, extents[0].Start);
                 Assert.Equal(3 * unit, extents[0].Length);
 
                 // Out of range
                 extents = new List<StreamExtent>(disk.Content.GetExtentsInRange(25 * unit, 4 * unit));
-                Assert.Equal(0, extents.Count);
+                Assert.Empty(extents);
 
                 // Non-unit multiples
                 extents = new List<StreamExtent>(disk.Content.GetExtentsInRange(21 * unit + 10, 20 * unit));
-                Assert.Equal(1, extents.Count);
+                Assert.Single(extents);
                 Assert.Equal(21 * unit + 10, extents[0].Start);
                 Assert.Equal(3 * unit - 10, extents[0].Length);
             }

--- a/Tests/LibraryTests/Xfs/SampleDataTests.cs
+++ b/Tests/LibraryTests/Xfs/SampleDataTests.cs
@@ -26,11 +26,11 @@ namespace LibraryTests.Xfs
             {
                 var manager = new VolumeManager(disk);
                 var logicalVolumes = manager.GetLogicalVolumes();
-                Assert.Equal(1, logicalVolumes.Length);
+                Assert.Single(logicalVolumes);
 
                 var volume = logicalVolumes[0];
                 var filesystems = FileSystemManager.DetectFileSystems(volume);
-                Assert.Equal(1, filesystems.Length);
+                Assert.Single(filesystems);
 
                 var filesystem = filesystems[0];
                 Assert.Equal("xfs", filesystem.Name);
@@ -58,11 +58,11 @@ namespace LibraryTests.Xfs
             {
                 var manager = new VolumeManager(disk);
                 var logicalVolumes = manager.GetLogicalVolumes();
-                Assert.Equal(1, logicalVolumes.Length);
+                Assert.Single(logicalVolumes);
 
                 var volume = logicalVolumes[0];
                 var filesystems = FileSystemManager.DetectFileSystems(volume);
-                Assert.Equal(1, filesystems.Length);
+                Assert.Single(filesystems);
 
                 var filesystem = filesystems[0];
                 Assert.Equal("xfs", filesystem.Name);
@@ -83,7 +83,7 @@ namespace LibraryTests.Xfs
         {
             Assert.True(xfs.DirectoryExists(""));
             Assert.True(xfs.FileExists("folder\\nested\\file"));
-            Assert.Equal(0, xfs.GetFileSystemEntries("empty").Length);
+            Assert.Empty(xfs.GetFileSystemEntries("empty"));
             for (int i = 1; i <= 1000; i++)
             {
                 Assert.True(xfs.FileExists($"folder\\file.{i}"), $"File file.{i} not found");

--- a/Tests/LibraryTests/Xva/VirtualMachineBuilderTest.cs
+++ b/Tests/LibraryTests/Xva/VirtualMachineBuilderTest.cs
@@ -43,7 +43,7 @@ namespace LibraryTests.Xva
 
             VirtualMachine vm = new VirtualMachine(xvaStream);
             List<Disk> disks = new List<Disk>(vm.Disks);
-            Assert.Equal(1, disks.Count);
+            Assert.Single(disks);
             Assert.Equal(0, disks[0].Capacity);
         }
 
@@ -67,7 +67,7 @@ namespace LibraryTests.Xva
 
             VirtualMachine vm = new VirtualMachine(xvaStream);
             List<Disk> disks = new List<Disk>(vm.Disks);
-            Assert.Equal(1, disks.Count);
+            Assert.Single(disks);
             Assert.Equal(10 * 1024 * 1024, disks[0].Capacity);
 
             Stream diskContent = disks[0].Content;


### PR DESCRIPTION
- Use `Assert.Single`, `Assert.True` and `Assert.False` instead of `Assert.Equal` constructs
- Mark theories with the `[Theory]` attribute
- Make non-test methods private