### PR TITLE
HFS+: Add support for compression type 9 ("DECMPFS_TYPE_RAW_ATTR")

### DIFF
--- a/Library/DiscUtils.HfsPlus/CompressionAttribute.cs
+++ b/Library/DiscUtils.HfsPlus/CompressionAttribute.cs
@@ -45,7 +45,7 @@ namespace DiscUtils.HfsPlus
             get { return Encoding.ASCII.GetString(BitConverter.GetBytes(_compressionMagic)); }
         }
 
-        public uint CompressionType { get; private set; }
+        public FileCompressionType CompressionType { get; private set; }
 
         public static int Size
         {
@@ -61,7 +61,7 @@ namespace DiscUtils.HfsPlus
             _reserved1 = EndianUtilities.ToUInt32BigEndian(buffer, offset + 8);
             AttrSize = EndianUtilities.ToUInt32BigEndian(buffer, offset + 12);
             _compressionMagic = EndianUtilities.ToUInt32BigEndian(buffer, offset + 16);
-            CompressionType = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 20);
+            CompressionType = (FileCompressionType)EndianUtilities.ToUInt32LittleEndian(buffer, offset + 20);
             UncompressedSize = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 24);
             _reserved3 = EndianUtilities.ToUInt32BigEndian(buffer, offset + 28);
 

--- a/Library/DiscUtils.HfsPlus/File.cs
+++ b/Library/DiscUtils.HfsPlus/File.cs
@@ -109,93 +109,93 @@ namespace DiscUtils.HfsPlus
                     CompressionAttribute compressionAttribute = new CompressionAttribute();
                     compressionAttribute.ReadFrom(compressionAttributeData, 0);
 
-                    // There are three possibilities:
-                    // - The file is very small and embedded "as is" in the compression attribute
-                    // - The file is small and is embedded as a compressed stream in the compression attribute
-                    // - The file is large and is embedded as a compressed stream in the resource fork 
-                    if (compressionAttribute.CompressionType == 3
-                        && compressionAttribute.UncompressedSize == compressionAttribute.AttrSize - 0x11)
+                    // There are multiple possibilities, not all of which are supported by DiscUtils.HfsPlus.
+                    // See FileCompressionType for a full description of all possibilities.
+                    switch (compressionAttribute.CompressionType)
                     {
-                        // Inline, no compression, very small file
-                        MemoryStream stream = new MemoryStream(
-                            compressionAttributeData,
-                            CompressionAttribute.Size + 1,
-                            (int)compressionAttribute.UncompressedSize,
-                            false);
+                        case FileCompressionType.ZlibAttribute:
+                            if (compressionAttribute.UncompressedSize == compressionAttribute.AttrSize - 0x11)
+                            {
+                                // Inline, no compression, very small file
+                                MemoryStream stream = new MemoryStream(
+                                    compressionAttributeData,
+                                    CompressionAttribute.Size + 1,
+                                    (int)compressionAttribute.UncompressedSize,
+                                    false);
 
-                        return new StreamBuffer(stream, Ownership.Dispose);
+                                return new StreamBuffer(stream, Ownership.Dispose);
+                            }
+                            else
+                            {
+                                // Inline, but we must decompress
+                                MemoryStream stream = new MemoryStream(
+                                    compressionAttributeData,
+                                    CompressionAttribute.Size,
+                                    compressionAttributeData.Length - CompressionAttribute.Size,
+                                    false);
+
+                                // The usage upstream will want to seek or set the position, the ZlibBuffer
+                                // wraps around a zlibstream and allows for this (in a limited fashion).
+                                ZlibStream compressedStream = new ZlibStream(stream, CompressionMode.Decompress, false);
+                                return new ZlibBuffer(compressedStream, Ownership.Dispose);
+                            }
+
+                        case FileCompressionType.ZlibResource:
+                            // The data is stored in the resource fork.
+                            FileBuffer buffer = new FileBuffer(Context, fileInfo.ResourceFork, fileInfo.FileId);
+                            CompressionResourceHeader compressionFork = new CompressionResourceHeader();
+                            byte[] compressionForkData = new byte[CompressionResourceHeader.Size];
+                            buffer.Read(0, compressionForkData, 0, CompressionResourceHeader.Size);
+                            compressionFork.ReadFrom(compressionForkData, 0);
+
+                            // The data is compressed in a number of blocks. Each block originally accounted for
+                            // 0x10000 bytes (that's 64 KB) of data. The compressed size may vary.
+                            // The data in each block can be read using a SparseStream. The first block contains
+                            // the zlib header but the others don't, so we read them directly as deflate streams.
+                            // For each block, we create a separate stream which we later aggregate.
+                            CompressionResourceBlockHead blockHeader = new CompressionResourceBlockHead();
+                            byte[] blockHeaderData = new byte[CompressionResourceBlockHead.Size];
+                            buffer.Read(compressionFork.HeaderSize, blockHeaderData, 0, CompressionResourceBlockHead.Size);
+                            blockHeader.ReadFrom(blockHeaderData, 0);
+
+                            uint blockCount = blockHeader.NumBlocks;
+                            CompressionResourceBlock[] blocks = new CompressionResourceBlock[blockCount];
+                            SparseStream[] streams = new SparseStream[blockCount];
+
+                            for (int i = 0; i < blockCount; i++)
+                            {
+                                // Read the block data, first into a buffer and the into the class.
+                                blocks[i] = new CompressionResourceBlock();
+                                byte[] blockData = new byte[CompressionResourceBlock.Size];
+                                buffer.Read(
+                                    compressionFork.HeaderSize + CompressionResourceBlockHead.Size +
+                                    i * CompressionResourceBlock.Size,
+                                    blockData,
+                                    0,
+                                    blockData.Length);
+                                blocks[i].ReadFrom(blockData, 0);
+
+                                // Create a SubBuffer which points to the data window that corresponds to the block.
+                                SubBuffer subBuffer = new SubBuffer(
+                                    buffer,
+                                    compressionFork.HeaderSize + blocks[i].Offset + 6, blocks[i].DataSize);
+
+                                // ... convert it to a stream
+                                BufferStream stream = new BufferStream(subBuffer, FileAccess.Read);
+
+                                // ... and create a deflate stream. Because we will concatenate the streams, the streams
+                                // must report on their size. We know the size (0x10000) so we pass it as a parameter.
+                                DeflateStream s = new SizedDeflateStream(stream, CompressionMode.Decompress, false, 0x10000);
+                                streams[i] = SparseStream.FromStream(s, Ownership.Dispose);
+                            }
+
+                            // Finally, concatenate the streams together and that's about it.
+                            ConcatStream concatStream = new ConcatStream(Ownership.Dispose, streams);
+                            return new ZlibBuffer(concatStream, Ownership.Dispose);
+
+                        default:
+                            throw new NotSupportedException($"The HfsPlus compression type {compressionAttribute.CompressionType} is not supported by DiscUtils.HfsPlus");
                     }
-                    if (compressionAttribute.CompressionType == 3)
-                    {
-                        // Inline, but we must decompress
-                        MemoryStream stream = new MemoryStream(
-                            compressionAttributeData,
-                            CompressionAttribute.Size,
-                            compressionAttributeData.Length - CompressionAttribute.Size,
-                            false);
-
-                        // The usage upstream will want to seek or set the position, the ZlibBuffer
-                        // wraps around a zlibstream and allows for this (in a limited fashion).
-                        ZlibStream compressedStream = new ZlibStream(stream, CompressionMode.Decompress, false);
-                        return new ZlibBuffer(compressedStream, Ownership.Dispose);
-                    }
-                    if (compressionAttribute.CompressionType == 4)
-                    {
-                        // The data is stored in the resource fork.
-                        FileBuffer buffer = new FileBuffer(Context, fileInfo.ResourceFork, fileInfo.FileId);
-                        CompressionResourceHeader compressionFork = new CompressionResourceHeader();
-                        byte[] compressionForkData = new byte[CompressionResourceHeader.Size];
-                        buffer.Read(0, compressionForkData, 0, CompressionResourceHeader.Size);
-                        compressionFork.ReadFrom(compressionForkData, 0);
-
-                        // The data is compressed in a number of blocks. Each block originally accounted for
-                        // 0x10000 bytes (that's 64 KB) of data. The compressed size may vary.
-                        // The data in each block can be read using a SparseStream. The first block contains
-                        // the zlib header but the others don't, so we read them directly as deflate streams.
-                        // For each block, we create a separate stream which we later aggregate.
-                        CompressionResourceBlockHead blockHeader = new CompressionResourceBlockHead();
-                        byte[] blockHeaderData = new byte[CompressionResourceBlockHead.Size];
-                        buffer.Read(compressionFork.HeaderSize, blockHeaderData, 0, CompressionResourceBlockHead.Size);
-                        blockHeader.ReadFrom(blockHeaderData, 0);
-
-                        uint blockCount = blockHeader.NumBlocks;
-                        CompressionResourceBlock[] blocks = new CompressionResourceBlock[blockCount];
-                        SparseStream[] streams = new SparseStream[blockCount];
-
-                        for (int i = 0; i < blockCount; i++)
-                        {
-                            // Read the block data, first into a buffer and the into the class.
-                            blocks[i] = new CompressionResourceBlock();
-                            byte[] blockData = new byte[CompressionResourceBlock.Size];
-                            buffer.Read(
-                                compressionFork.HeaderSize + CompressionResourceBlockHead.Size +
-                                i * CompressionResourceBlock.Size,
-                                blockData,
-                                0,
-                                blockData.Length);
-                            blocks[i].ReadFrom(blockData, 0);
-
-                            // Create a SubBuffer which points to the data window that corresponds to the block.
-                            SubBuffer subBuffer = new SubBuffer(
-                                buffer,
-                                compressionFork.HeaderSize + blocks[i].Offset + 6, blocks[i].DataSize);
-
-                            // ... convert it to a stream
-                            BufferStream stream = new BufferStream(subBuffer, FileAccess.Read);
-
-                            // ... and create a deflate stream. Because we will concatenate the streams, the streams
-                            // must report on their size. We know the size (0x10000) so we pass it as a parameter.
-                            DeflateStream s = new SizedDeflateStream(stream, CompressionMode.Decompress, false, 0x10000);
-                            streams[i] = SparseStream.FromStream(s, Ownership.Dispose);
-                        }
-
-                        // Finally, concatenate the streams together and that's about it.
-                        ConcatStream concatStream = new ConcatStream(Ownership.Dispose, streams);
-                        return new ZlibBuffer(concatStream, Ownership.Dispose);
-                    }
-
-                    // Fall back to the default behavior.
-                    return new FileBuffer(Context, fileInfo.DataFork, fileInfo.FileId);
                 }
                 return new FileBuffer(Context, fileInfo.DataFork, fileInfo.FileId);
             }

--- a/Library/DiscUtils.HfsPlus/File.cs
+++ b/Library/DiscUtils.HfsPlus/File.cs
@@ -193,6 +193,16 @@ namespace DiscUtils.HfsPlus
                             ConcatStream concatStream = new ConcatStream(Ownership.Dispose, streams);
                             return new ZlibBuffer(concatStream, Ownership.Dispose);
 
+                        case FileCompressionType.RawAttribute:
+                            // Inline, no compression, very small file
+                            return new StreamBuffer(
+                                new MemoryStream(
+                                    compressionAttributeData,
+                                    CompressionAttribute.Size,
+                                    (int)compressionAttribute.UncompressedSize,
+                                    false),
+                                Ownership.Dispose);
+
                         default:
                             throw new NotSupportedException($"The HfsPlus compression type {compressionAttribute.CompressionType} is not supported by DiscUtils.HfsPlus");
                     }

--- a/Library/DiscUtils.HfsPlus/FileCompressionType.cs
+++ b/Library/DiscUtils.HfsPlus/FileCompressionType.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DiscUtils.HfsPlus
+{
+    /// <summary>
+    /// If a file is compressed, then it will have an extended attribute with name <c>com.apple.decmpfs</c>.
+    /// Different compression types can be applied to a file, and this enum describes which compression type
+    /// is being used.
+    /// </summary>
+    /// <seealso href="https://github.com/sleuthkit/sleuthkit/blob/dcf8136b04e77e8c28056e5b4639c97ffefa585e/tsk/fs/decmpfs.h"/>
+    /// <seealso href="https://github.com/libyal/libfsapfs/blob/main/documentation/Apple%20File%20System%20(APFS).asciidoc#compression_method"/>
+    /// <seealso href="https://github.com/RJVB/afsctool/issues/6#issuecomment-374620414"/>
+    public enum FileCompressionType : uint
+    {
+        /// <summary>
+        /// The compressed data is stored in the compression attribute, following the compression
+        /// header. If the first byte of that data is 0xF, then the data is not compressed.
+        /// Otherwise, the data is zlib-compressed.
+        /// </summary>
+        ZlibAttribute = 3,
+
+        /// <summary>
+        /// The compressed data is stored in the file's resource fork. The resource fork
+        /// contains a single resource of type CMPF. The beginning of the resource is a
+        /// table of offsets for successive zlib compression units within the resource.
+        /// The compressed data is chunked in 64KB units.
+        /// </summary>
+        ZlibResource = 4,
+
+        /// <summary>
+        /// The file is dataless, that is, the uncompressed data contains 0-byte values.
+        /// </summary>
+        Dataless = 5,
+
+        /// <summary>
+        /// The compressed data is stored in the compression attribute, following the compression
+        /// header. The data is LZVN-compressed.
+        /// </summary>
+        LzvnAttribute = 7,
+
+        /// <summary>
+        /// The compressed data is stored in the file's resource fork. The resource fork
+        /// contains a single resource of type CMPF. The beginning of the resource is a
+        /// table of offsets for successive LZVN compression units within the resource.
+        /// The compressed data is chunked in 64KB units.
+        /// </summary>
+        LzvnResource = 8,
+
+        /// <summary>
+        /// The data is stored in the compression attribute, following the compression
+        /// header. The data is not compressed.
+        /// </summary>
+        RawAttribute = 9,
+
+        /// <summary>
+        /// The compressed data is stored in the file's resource fork. The resource fork
+        /// contains a single resource of type CMPF. The beginning of the resource is a
+        /// table of offsets for successive uncompressed units within the resource.
+        /// The data is chunked in 64KB units.
+        /// </summary>
+        RawResource = 10,
+
+        /// <summary>
+        /// The compressed data is stored in the compression attribute, following the compression
+        /// header. The data is LZFSE-compressed.
+        /// </summary>
+        LzfseAttribute = 11,
+
+        /// <summary>
+        /// The compressed data is stored in the file's resource fork. The resource fork
+        /// contains a single resource of type CMPF. The beginning of the resource is a
+        /// table of offsets for successive LZFSE compression units within the resource.
+        /// The compressed data is chunked in 64KB units.
+        /// </summary>
+        LzfseResource = 12,
+    }
+}

--- a/Tests/LibraryTests/HfsPlus/HfsPlusTest.cs
+++ b/Tests/LibraryTests/HfsPlus/HfsPlusTest.cs
@@ -27,7 +27,6 @@ using DiscUtils.Setup;
 using DiscUtils.Streams;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace LibraryTests.HfsPlus
@@ -44,8 +43,7 @@ namespace LibraryTests.HfsPlus
 #if NETCOREAPP
         public static IEnumerable<object[]> GetDeveloperDiskImages()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-                || !Directory.Exists(DeviceSupportPath))
+            if (!Directory.Exists(DeviceSupportPath))
             {
                 yield break;
             }
@@ -57,7 +55,7 @@ namespace LibraryTests.HfsPlus
         }
 
         [MemberData(nameof(GetDeveloperDiskImages))]
-        [Theory]
+        [MacOSOnlyTheory]
         public void ReadFilesystemTest(string path)
         {
             using (Stream developerDiskImageStream = File.OpenRead(path))

--- a/Tests/LibraryTests/HfsPlus/HfsPlusTest.cs
+++ b/Tests/LibraryTests/HfsPlus/HfsPlusTest.cs
@@ -22,7 +22,10 @@
 
 using DiscUtils;
 using DiscUtils.Dmg;
+using DiscUtils.HfsPlus;
+using DiscUtils.Setup;
 using DiscUtils.Streams;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using Xunit;
@@ -31,16 +34,33 @@ namespace LibraryTests.HfsPlus
 {
     public class HfsPlusTest
     {
-#if NETCOREAPP
-        [Fact]
-        public void ReadFilesystemTest()
+        private const string SystemVersionPath = @"System\Library\CoreServices\SystemVersion.plist";
+        private const string DeviceSupportPath = "/Applications/Xcode.app/Content/Developer/Platforms/iPhoneOS.Platform/DeviceSupport/";
+        static HfsPlusTest()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            SetupHelper.RegisterAssembly(typeof(HfsPlusFileSystem).Assembly);
+        }
+
+#if NETCOREAPP
+        public static IEnumerable<object[]> GetDeveloperDiskImages()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                || !Directory.Exists(DeviceSupportPath))
             {
-                return;
+                yield break;
             }
 
-            using (Stream developerDiskImageStream = File.OpenRead(@"/Applications/Xcode.app/Content/Developer/Platforms/iPhoneOS.Platform/DeviceSupport/13.0/DeveloperDiskImage.dmg"))
+            foreach (var directory in Directory.GetDirectories(DeviceSupportPath))
+            {
+                yield return new object[] { Path.Combine(directory, "DeveloperDiskImage.dmg") };
+            }
+        }
+
+        [MemberData(nameof(GetDeveloperDiskImages))]
+        [Theory]
+        public void ReadFilesystemTest(string path)
+        {
+            using (Stream developerDiskImageStream = File.OpenRead(path))
             using (var disk = new Disk(developerDiskImageStream, Ownership.None))
             {
                 // Find the first (and supposedly, only, HFS partition)
@@ -48,10 +68,20 @@ namespace LibraryTests.HfsPlus
                 foreach (var volume in volumes)
                 {
                     var fileSystems = FileSystemManager.DetectFileSystems(volume);
-                    foreach (var fileSystem in fileSystems)
+
+                    var fileSystem = Assert.Single(fileSystems);
+                    Assert.Equal("HFS+", fileSystem.Name);
+
+                    using (HfsPlusFileSystem hfs = (HfsPlusFileSystem)fileSystem.Open(volume))
                     {
-                        if (fileSystem.Name == "HFS+")
+                        Assert.True(hfs.FileExists(SystemVersionPath));
+
+                        using (Stream systemVersionStream = hfs.OpenFile(SystemVersionPath, FileMode.Open, FileAccess.Read))
+                        using (MemoryStream copyStream = new MemoryStream())
                         {
+                            Assert.NotEqual(0, systemVersionStream.Length);
+                            systemVersionStream.CopyTo(copyStream);
+                            Assert.Equal(systemVersionStream.Length, copyStream.Length);
                         }
                     }
                 }

--- a/Tests/LibraryTests/MacOSOnlyTheoryAttribute.cs
+++ b/Tests/LibraryTests/MacOSOnlyTheoryAttribute.cs
@@ -1,0 +1,49 @@
+﻿//
+// Copyright (c) 2020, Quamotion bv
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace LibraryTests
+{
+    public class MacOSOnlyTheoryAttribute : TheoryAttribute
+    {
+        public override string Skip
+        {
+            get
+            {
+#if NETCOREAPP
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    return "This test runs on macOS only";
+                }
+
+                return null;
+#else
+                return "This test runs on macOS only";
+#endif
+            }
+            set => throw new NotSupportedException();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for files in the HFS+ file system which are compressed using compression type 9 ("`DECMPFS_TYPE_RAW_ATTR `"). This compression type means the file is stored uncompressed in the `com.apple.decmpfs` attribute.

The best write-up of the compression types I could find is here: https://github.com/RJVB/afsctool/issues/6#issuecomment-374620414 .

Only a couple of these compression types are supported by DiscUtils. I've updated the code to error out (instead of silently returning an invalid stream).
