### PR TITLE
Push symbols to MyGet

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,7 @@ after_test:
 deploy:
   - provider: NuGet
     server: https://www.myget.org/F/discutils/api/v2/package
+    symbol_server: https://www.myget.org/F/discutils/api/v2/package
     api_key:
       secure: foGROcPrYEku4LqHLdwidY8kXnpLsAB1YOBufMY0P9AptYpUzySgx5gezRcZ9vma
     on:


### PR DESCRIPTION
CI in the develop branch is failing because the `symbol_server` property is not set for the MyGet feed, causing symbols to be pushed to NuGet instead (which fails, because the API key is incorrect).

This should fix CI on the develop branch.