### PR TITLE
Improve DiscUtils extensibility

### DIFF
--- a/Library/DiscUtils.Core/ApplePartitionMap/PartitionMapEntry.cs
+++ b/Library/DiscUtils.Core/ApplePartitionMap/PartitionMapEntry.cs
@@ -72,7 +72,7 @@ namespace DiscUtils.ApplePartitionMap
             get { return Type; }
         }
 
-        internal override PhysicalVolumeType VolumeType
+        public override PhysicalVolumeType VolumeType
         {
             get { return PhysicalVolumeType.ApplePartition; }
         }

--- a/Library/DiscUtils.Core/FileLocator.cs
+++ b/Library/DiscUtils.Core/FileLocator.cs
@@ -27,7 +27,7 @@ using DiscUtils.Setup;
 
 namespace DiscUtils
 {
-    internal abstract class FileLocator
+    public abstract class FileLocator
     {
         public abstract bool Exists(string fileName);
 

--- a/Library/DiscUtils.Core/Internal/VirtualDiskFactory.cs
+++ b/Library/DiscUtils.Core/Internal/VirtualDiskFactory.cs
@@ -25,7 +25,7 @@ using System.IO;
 
 namespace DiscUtils.Internal
 {
-    internal abstract class VirtualDiskFactory
+    public abstract class VirtualDiskFactory
     {
         public abstract string[] Variants { get; }
 

--- a/Library/DiscUtils.Core/Internal/VirtualDiskFactoryAttribute.cs
+++ b/Library/DiscUtils.Core/Internal/VirtualDiskFactoryAttribute.cs
@@ -25,7 +25,7 @@ using System;
 namespace DiscUtils.Internal
 {
     [AttributeUsage(AttributeTargets.Class)]
-    internal sealed class VirtualDiskFactoryAttribute : Attribute
+    public sealed class VirtualDiskFactoryAttribute : Attribute
     {
         public VirtualDiskFactoryAttribute(string type, string fileExtensions)
         {

--- a/Library/DiscUtils.Core/Partitions/BiosPartitionInfo.cs
+++ b/Library/DiscUtils.Core/Partitions/BiosPartitionInfo.cs
@@ -119,7 +119,7 @@ namespace DiscUtils.Partitions
             get { return _record.FriendlyPartitionType; }
         }
 
-        internal override PhysicalVolumeType VolumeType
+        public override PhysicalVolumeType VolumeType
         {
             get { return PhysicalVolumeType.BiosPartition; }
         }

--- a/Library/DiscUtils.Core/Partitions/GuidPartitionInfo.cs
+++ b/Library/DiscUtils.Core/Partitions/GuidPartitionInfo.cs
@@ -103,7 +103,7 @@ namespace DiscUtils.Partitions
             get { return _entry.FriendlyPartitionType; }
         }
 
-        internal override PhysicalVolumeType VolumeType
+        public override PhysicalVolumeType VolumeType
         {
             get { return PhysicalVolumeType.GptPartition; }
         }

--- a/Library/DiscUtils.Core/Partitions/PartitionInfo.cs
+++ b/Library/DiscUtils.Core/Partitions/PartitionInfo.cs
@@ -72,7 +72,7 @@ namespace DiscUtils.Partitions
         /// <summary>
         /// Gets the physical volume type for this type of partition.
         /// </summary>
-        internal abstract PhysicalVolumeType VolumeType { get; }
+        public abstract PhysicalVolumeType VolumeType { get; }
 
         /// <summary>
         /// Opens a stream that accesses the partition's contents.

--- a/Library/DiscUtils.Core/Raw/DiskImageFile.cs
+++ b/Library/DiscUtils.Core/Raw/DiskImageFile.cs
@@ -61,7 +61,7 @@ namespace DiscUtils.Raw
             Geometry = geometry ?? DetectGeometry(Content);
         }
 
-        internal override long Capacity
+        public override long Capacity
         {
             get { return Content.Length; }
         }
@@ -97,7 +97,7 @@ namespace DiscUtils.Raw
             get { return false; }
         }
 
-        internal override FileLocator RelativeFileLocator
+        public override FileLocator RelativeFileLocator
         {
             get { return null; }
         }

--- a/Library/DiscUtils.Core/VirtualDiskLayer.cs
+++ b/Library/DiscUtils.Core/VirtualDiskLayer.cs
@@ -43,7 +43,7 @@ namespace DiscUtils
         /// <summary>
         /// Gets the capacity of the disk (in bytes).
         /// </summary>
-        internal abstract long Capacity { get; }
+        public abstract long Capacity { get; }
 
         /// <summary>
         /// Gets and sets the logical extents that make up this layer.
@@ -82,7 +82,7 @@ namespace DiscUtils
         /// <remarks>
         /// Typically used to locate parent disks.
         /// </remarks>
-        internal abstract FileLocator RelativeFileLocator { get; }
+        public abstract FileLocator RelativeFileLocator { get; }
 
         /// <summary>
         /// Disposes of this instance, freeing underlying resources.

--- a/Library/DiscUtils.Dmg/DiskImageFile.cs
+++ b/Library/DiscUtils.Dmg/DiskImageFile.cs
@@ -63,7 +63,7 @@ namespace DiscUtils.Dmg
 
         public UdifBuffer Buffer { get; }
 
-        internal override long Capacity
+        public override long Capacity
         {
             get { return Buffer == null ? _stream.Length : Buffer.Capacity; }
         }
@@ -89,7 +89,7 @@ namespace DiscUtils.Dmg
             get { return false; }
         }
 
-        internal override FileLocator RelativeFileLocator
+        public override FileLocator RelativeFileLocator
         {
             get { throw new NotImplementedException(); }
         }

--- a/Library/DiscUtils.Dmg/UdifPartitionInfo.cs
+++ b/Library/DiscUtils.Dmg/UdifPartitionInfo.cs
@@ -67,7 +67,7 @@ namespace DiscUtils.Dmg
             get { return GetType().FullName; }
         }
 
-        internal override PhysicalVolumeType VolumeType
+        public override PhysicalVolumeType VolumeType
         {
             get { return PhysicalVolumeType.ApplePartition; }
         }

--- a/Library/DiscUtils.OpticalDiscSharing/DiscImageFile.cs
+++ b/Library/DiscUtils.OpticalDiscSharing/DiscImageFile.cs
@@ -43,7 +43,7 @@ namespace DiscUtils.OpticalDiscSharing
             Content = new BlockCacheStream(Content, Ownership.Dispose);
         }
 
-        internal override long Capacity
+        public override long Capacity
         {
             get { return Content.Length; }
         }
@@ -66,7 +66,7 @@ namespace DiscUtils.OpticalDiscSharing
             get { return false; }
         }
 
-        internal override FileLocator RelativeFileLocator
+        public override FileLocator RelativeFileLocator
         {
             get { return null; }
         }

--- a/Library/DiscUtils.OpticalDisk/DiscImageFile.cs
+++ b/Library/DiscUtils.OpticalDisk/DiscImageFile.cs
@@ -91,7 +91,7 @@ namespace DiscUtils.OpticalDisk
             }
         }
 
-        internal override long Capacity
+        public override long Capacity
         {
             get { return Content.Length; }
         }
@@ -128,7 +128,7 @@ namespace DiscUtils.OpticalDisk
             get { return false; }
         }
 
-        internal override FileLocator RelativeFileLocator
+        public override FileLocator RelativeFileLocator
         {
             get { return null; }
         }

--- a/Library/DiscUtils.Vdi/DiskImageFile.cs
+++ b/Library/DiscUtils.Vdi/DiskImageFile.cs
@@ -71,7 +71,7 @@ namespace DiscUtils.Vdi
             ReadHeader();
         }
 
-        internal override long Capacity
+        public override long Capacity
         {
             get { return _header.DiskSize; }
         }
@@ -111,7 +111,7 @@ namespace DiscUtils.Vdi
             get { return _header.ImageType == ImageType.Differencing || _header.ImageType == ImageType.Undo; }
         }
 
-        internal override FileLocator RelativeFileLocator
+        public override FileLocator RelativeFileLocator
         {
             // Differencing disks not yet supported.
             get { return null; }

--- a/Library/DiscUtils.Vhd/DiskImageFile.cs
+++ b/Library/DiscUtils.Vhd/DiskImageFile.cs
@@ -129,7 +129,7 @@ namespace DiscUtils.Vhd
             }
         }
 
-        internal override long Capacity
+        public override long Capacity
         {
             get { return _footer.CurrentSize; }
         }
@@ -211,7 +211,7 @@ namespace DiscUtils.Vhd
             get { return _dynamicHeader == null ? Guid.Empty : _dynamicHeader.ParentUniqueId; }
         }
 
-        internal override FileLocator RelativeFileLocator
+        public override FileLocator RelativeFileLocator
         {
             get { return _fileLocator; }
         }

--- a/Library/DiscUtils.Vhdx/DiskImageFile.cs
+++ b/Library/DiscUtils.Vhdx/DiskImageFile.cs
@@ -148,7 +148,7 @@ namespace DiscUtils.Vhdx
             }
         }
 
-        internal override long Capacity
+        public override long Capacity
         {
             get { return (long)_metadata.DiskSize; }
         }
@@ -258,7 +258,7 @@ namespace DiscUtils.Vhdx
             }
         }
 
-        internal override FileLocator RelativeFileLocator
+        public override FileLocator RelativeFileLocator
         {
             get { return _fileLocator; }
         }

--- a/Library/DiscUtils.Vmdk/DiskImageFile.cs
+++ b/Library/DiscUtils.Vmdk/DiskImageFile.cs
@@ -188,7 +188,7 @@ namespace DiscUtils.Vmdk
         /// <summary>
         /// Gets the capacity of this disk (in bytes).
         /// </summary>
-        internal override long Capacity
+        public override long Capacity
         {
             get
             {
@@ -291,7 +291,7 @@ namespace DiscUtils.Vmdk
         /// <remarks>
         /// Typically used to locate parent disks.
         /// </remarks>
-        internal override FileLocator RelativeFileLocator
+        public override FileLocator RelativeFileLocator
         {
             get { return _fileLocator; }
         }

--- a/Library/DiscUtils.Xva/DiskLayer.cs
+++ b/Library/DiscUtils.Xva/DiskLayer.cs
@@ -44,7 +44,7 @@ namespace DiscUtils.Xva
         /// <summary>
         /// Gets the capacity of the layer (in bytes).
         /// </summary>
-        internal override long Capacity
+        public override long Capacity
         {
             get { return _capacity; }
         }
@@ -76,7 +76,7 @@ namespace DiscUtils.Xva
             get { return false; }
         }
 
-        internal override FileLocator RelativeFileLocator
+        public override FileLocator RelativeFileLocator
         {
             get { return null; }
         }


### PR DESCRIPTION
Currently, it's difficult to build and maintain out-of-tree extensions to DiscUtils. Some classes which you need to implement are either `internal`, or have (abstract) methods or properties which are `internal`. This makes it impossible to implement these classes in a 3rd party project.

This commit improves DiscUtils extensibility a bit by:
- Making `VirtualDiskFactory`, `VirtualDiskFactoryAttribute` public
- Making `FileLocator` public
- Making `PartitionInfo.VolumeType` public
- Making `VirtualDiskLayer.Capacity` and `VirtualDiskLayer.RelativeFileLocator` public