### PR TITLE
Add .NET 5.0 support, remove netstandard1.5 workarounds

### DIFF
--- a/Library/DiscUtils.Containers/DiscUtils.Containers.csproj
+++ b/Library/DiscUtils.Containers/DiscUtils.Containers.csproj
@@ -16,9 +16,6 @@
     <ProjectReference Include="..\DiscUtils.Vmdk\DiscUtils.Vmdk.csproj" />
     <ProjectReference Include="..\DiscUtils.Wim\DiscUtils.Wim.csproj" />
     <ProjectReference Include="..\DiscUtils.Xva\DiscUtils.Xva.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.5'">
     <ProjectReference Include="..\DiscUtils.OpticalDiscSharing\DiscUtils.OpticalDiscSharing.csproj" />
   </ItemGroup>
 

--- a/Library/DiscUtils.Core/CoreCompat/ReflectionHelper.cs
+++ b/Library/DiscUtils.Core/CoreCompat/ReflectionHelper.cs
@@ -9,83 +9,47 @@ namespace DiscUtils.CoreCompat
     {
         public static bool IsEnum(Type type)
         {
-#if NETSTANDARD1_5
-            return type.GetTypeInfo().IsEnum;
-#else
             return type.IsEnum;
-#endif
         }
 
         public static Attribute GetCustomAttribute(PropertyInfo property, Type attributeType)
         {
-#if NETSTANDARD1_5
-            return property.GetCustomAttribute(attributeType);
-#else
             return Attribute.GetCustomAttribute(property, attributeType);
-#endif
         }
 
         public static Attribute GetCustomAttribute(PropertyInfo property, Type attributeType, bool inherit)
         {
-#if NETSTANDARD1_5
-            return property.GetCustomAttribute(attributeType, inherit);
-#else
             return Attribute.GetCustomAttribute(property, attributeType, inherit);
-#endif
         }
 
         public static Attribute GetCustomAttribute(FieldInfo field, Type attributeType)
         {
-#if NETSTANDARD1_5
-            return field.GetCustomAttribute(attributeType);
-#else
             return Attribute.GetCustomAttribute(field, attributeType);
-#endif
         }
 
         public static Attribute GetCustomAttribute(Type type, Type attributeType)
         {
-#if NETSTANDARD1_5
-            return type.GetTypeInfo().GetCustomAttribute(attributeType);
-#else
             return Attribute.GetCustomAttribute(type, attributeType);
-#endif
         }
 
         public static Attribute GetCustomAttribute(Type type, Type attributeType, bool inherit)
         {
-#if NETSTANDARD1_5
-            return type.GetTypeInfo().GetCustomAttribute(attributeType, inherit);
-#else
             return Attribute.GetCustomAttribute(type, attributeType);
-#endif
         }
 
         public static IEnumerable<Attribute> GetCustomAttributes(Type type, Type attributeType, bool inherit)
         {
-#if NETSTANDARD1_5
-            return type.GetTypeInfo().GetCustomAttributes(attributeType, inherit);
-#else
             return Attribute.GetCustomAttributes(type, attributeType);
-#endif
         }
 
         public static Assembly GetAssembly(Type type)
         {
-#if NETSTANDARD1_5
-            return type.GetTypeInfo().Assembly;
-#else
             return type.Assembly;
-#endif
         }
 
         public static int SizeOf<T>()
         {
-#if NETSTANDARD1_5
-            return Marshal.SizeOf<T>();
-#else
             return Marshal.SizeOf(typeof(T));
-#endif
         }
     }
 }

--- a/Library/DiscUtils.Core/DiscUtils.Core.csproj
+++ b/Library/DiscUtils.Core/DiscUtils.Core.csproj
@@ -12,11 +12,13 @@
     <ProjectReference Include="..\DiscUtils.Streams\DiscUtils.Streams.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' OR '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Security.AccessControl" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.DriveInfo" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="System.Security.AccessControl" Version="5.0.0" />
+    
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Security.AccessControl" Version="5.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Core/Internal/LocalFileLocator.cs
+++ b/Library/DiscUtils.Core/Internal/LocalFileLocator.cs
@@ -54,11 +54,7 @@ namespace DiscUtils.Internal
             string combinedPath = Path.Combine(_dir, path);
             if (string.IsNullOrEmpty(combinedPath))
             {
-#if NETSTANDARD1_5
-                return Directory.GetCurrentDirectory();
-#else
                 return Environment.CurrentDirectory;
-#endif
             }
             return Path.GetFullPath(combinedPath);
         }

--- a/Library/DiscUtils.Core/InvalidFileSystemException.cs
+++ b/Library/DiscUtils.Core/InvalidFileSystemException.cs
@@ -22,19 +22,14 @@
 
 using System;
 using System.IO;
-
-#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
-#endif
 
 namespace DiscUtils
 {
     /// <summary>
     /// Exception thrown when some invalid file system data is found, indicating probably corruption.
     /// </summary>
-#if !NETSTANDARD1_5
     [Serializable]
-#endif
     public class InvalidFileSystemException : IOException
     {
         /// <summary>
@@ -57,7 +52,6 @@ namespace DiscUtils
         public InvalidFileSystemException(string message, Exception innerException)
             : base(message, innerException) {}
 
-#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the InvalidFileSystemException class.
         /// </summary>
@@ -67,6 +61,5 @@ namespace DiscUtils
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/Library/DiscUtils.Core/System/DateTimeOffsetExtensions.cs
+++ b/Library/DiscUtils.Core/System/DateTimeOffsetExtensions.cs
@@ -26,7 +26,6 @@
 #endif
         }
 
-#if !NETSTANDARD1_5
         /// <summary>
         /// Converts the current DateTimeOffset to Unix time.
         /// </summary>
@@ -37,6 +36,5 @@
             long unixTimeStampInTicks = (dateTimeOffset.ToUniversalTime() - DateTimeOffsetExtensions.UnixEpoch).Ticks;
             return unixTimeStampInTicks / TimeSpan.TicksPerSecond;
         }
-#endif
     }
 }

--- a/Library/DiscUtils.Iscsi/DiscUtils.Iscsi.csproj
+++ b/Library/DiscUtils.Iscsi/DiscUtils.Iscsi.csproj
@@ -11,10 +11,4 @@
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' OR '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
-    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-  </ItemGroup>
-
 </Project>

--- a/Library/DiscUtils.Iscsi/InvalidProtocolException.cs
+++ b/Library/DiscUtils.Iscsi/InvalidProtocolException.cs
@@ -22,18 +22,14 @@
 
 using System;
 
-#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
-#endif
 
 namespace DiscUtils.Iscsi
 {
     /// <summary>
     /// Exception thrown when a low-level iSCSI failure is detected.
     /// </summary>
-#if !NETSTANDARD1_5
     [Serializable]
-#endif
     public class InvalidProtocolException : IscsiException
     {
         /// <summary>
@@ -56,7 +52,6 @@ namespace DiscUtils.Iscsi
         public InvalidProtocolException(string message, Exception innerException)
             : base(message, innerException) {}
 
-#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the InvalidProtocolException class.
         /// </summary>
@@ -66,6 +61,5 @@ namespace DiscUtils.Iscsi
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/Library/DiscUtils.Iscsi/IscsiException.cs
+++ b/Library/DiscUtils.Iscsi/IscsiException.cs
@@ -25,16 +25,12 @@ using System.IO;
 
 namespace DiscUtils.Iscsi
 {
-#if !NETSTANDARD1_5
     using System.Runtime.Serialization;
-#endif
 
     /// <summary>
     /// Base exception for any iSCSI-related failures.
     /// </summary>
-#if !NETSTANDARD1_5
     [Serializable]
-#endif
     public class IscsiException : IOException
     {
         /// <summary>
@@ -57,7 +53,6 @@ namespace DiscUtils.Iscsi
         public IscsiException(string message, Exception innerException)
             : base(message, innerException) {}
 
-#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the IscsiException class.
         /// </summary>
@@ -67,6 +62,5 @@ namespace DiscUtils.Iscsi
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/Library/DiscUtils.Iscsi/LoginException.cs
+++ b/Library/DiscUtils.Iscsi/LoginException.cs
@@ -24,16 +24,12 @@ using System;
 
 namespace DiscUtils.Iscsi
 {
-#if !NETSTANDARD1_5
     using System.Runtime.Serialization;
-#endif
 
     /// <summary>
     /// Exception thrown when an authentication exception occurs.
     /// </summary>
-#if !NETSTANDARD1_5
     [Serializable]
-#endif
     public class LoginException : IscsiException
     {
         /// <summary>
@@ -64,7 +60,6 @@ namespace DiscUtils.Iscsi
         public LoginException(string message, LoginStatusCode code)
             : base("iSCSI login failure (" + code + "):" + message) {}
 
-#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the LoginException class.
         /// </summary>
@@ -74,6 +69,5 @@ namespace DiscUtils.Iscsi
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/Library/DiscUtils.Iscsi/ScsiCommandException.cs
+++ b/Library/DiscUtils.Iscsi/ScsiCommandException.cs
@@ -22,19 +22,15 @@
 
 using System;
 
-#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 using System.Security.Permissions;
-#endif
 
 namespace DiscUtils.Iscsi
 {
     /// <summary>
     /// Exception thrown when a low-level iSCSI failure is detected.
     /// </summary>
-#if !NETSTANDARD1_5
     [Serializable]
-#endif
     public class ScsiCommandException : IscsiException
     {
         private readonly byte[] _senseData;
@@ -113,7 +109,6 @@ namespace DiscUtils.Iscsi
             Status = status;
         }
 
-#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the ScsiCommandException class.
         /// </summary>
@@ -125,7 +120,6 @@ namespace DiscUtils.Iscsi
             Status = (ScsiStatus)info.GetByte("status");
             _senseData = (byte[])info.GetValue("senseData", typeof(byte[]));
         }
-#endif
 
         /// <summary>
         /// Gets the SCSI status associated with this exception.
@@ -137,8 +131,7 @@ namespace DiscUtils.Iscsi
         /// </summary>
         /// <param name="info">The serialization info.</param>
         /// <param name="context">The serialization context.</param>
-#if !NETSTANDARD1_5
-#if !NETSTANDARD
+#if !NETCOREAPP2_0_OR_GREATER
         [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.SerializationFormatter)]
 #endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -147,7 +140,6 @@ namespace DiscUtils.Iscsi
             info.AddValue("status", (byte)Status);
             info.AddValue("senseData", _senseData);
         }
-#endif
 
         /// <summary>
         /// Gets the SCSI sense data (if any) associated with this exception.

--- a/Library/DiscUtils.Nfs/DiscUtils.Nfs.csproj
+++ b/Library/DiscUtils.Nfs/DiscUtils.Nfs.csproj
@@ -11,9 +11,4 @@
     <ProjectReference Include="..\DiscUtils.Core\DiscUtils.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' OR '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-  </ItemGroup>
-
 </Project>

--- a/Library/DiscUtils.Nfs/Nfs3Exception.cs
+++ b/Library/DiscUtils.Nfs/Nfs3Exception.cs
@@ -22,20 +22,15 @@
 
 using System;
 using System.IO;
-
-#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
 using System.Security.Permissions;
-#endif
 
 namespace DiscUtils.Nfs
 {
     /// <summary>
     /// Exception thrown when some invalid file system data is found, indicating probably corruption.
     /// </summary>
-#if !NETSTANDARD1_5
     [Serializable]
-#endif
     public sealed class Nfs3Exception : IOException
     {
         /// <summary>
@@ -79,7 +74,6 @@ namespace DiscUtils.Nfs
             NfsStatus = status;
         }
 
-#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the Nfs3Exception class.
         /// </summary>
@@ -90,26 +84,25 @@ namespace DiscUtils.Nfs
         {
             NfsStatus = (Nfs3Status)info.GetInt32("Status");
         }
-#endif
 
         /// <summary>
         /// Gets the NFS status code that lead to the exception.
         /// </summary>
         public Nfs3Status NfsStatus { get; } = Nfs3Status.Unknown;
 
-#if !NETSTANDARD1_5
         /// <summary>
         /// Serializes this exception.
         /// </summary>
         /// <param name="info">The object to populate with serialized data.</param>
         /// <param name="context">The context for this serialization.</param>
+#if !NETCOREAPP2_0_OR_GREATER
         [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.SerializationFormatter)]
+#endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             info.AddValue("Status", (int)NfsStatus);
             base.GetObjectData(info, context);
         }
-#endif
 
         private static string GenerateMessage(Nfs3Status status)
         {

--- a/Library/DiscUtils.Nfs/RpcException.cs
+++ b/Library/DiscUtils.Nfs/RpcException.cs
@@ -26,16 +26,12 @@ using System.IO;
 
 namespace DiscUtils.Nfs
 {
-#if !NETSTANDARD1_5
     using System.Runtime.Serialization;
-#endif
 
     /// <summary>
     /// Exception thrown when some invalid file system data is found, indicating probably corruption.
     /// </summary>
-#if !NETSTANDARD1_5
     [Serializable]
-#endif
     public sealed class RpcException : IOException
     {
         /// <summary>
@@ -65,7 +61,6 @@ namespace DiscUtils.Nfs
         internal RpcException(RpcReplyHeader reply)
             : base(GenerateMessage(reply)) {}
 
-#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the RpcException class.
         /// </summary>
@@ -75,7 +70,6 @@ namespace DiscUtils.Nfs
             : base(info, context)
         {
         }
-#endif
 
         private static string GenerateMessage(RpcReplyHeader reply)
         {

--- a/Library/DiscUtils.Ntfs/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Ntfs/Properties/AssemblyInfo.cs
@@ -1,10 +1,18 @@
 ﻿using System.Runtime.InteropServices;
 
+#if NET5_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
+
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 
 [assembly: ComVisible(false)]
+
+#if NET5_0_OR_GREATER
+[assembly: SupportedOSPlatform("windows")]
+#endif
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 

--- a/Library/DiscUtils.Registry/DiscUtils.Registry.csproj
+++ b/Library/DiscUtils.Registry/DiscUtils.Registry.csproj
@@ -12,9 +12,9 @@
     <ProjectReference Include="..\DiscUtils.Streams\DiscUtils.Streams.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' OR '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.3.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Library/DiscUtils.Registry/DiscUtils.Registry.csproj
+++ b/Library/DiscUtils.Registry/DiscUtils.Registry.csproj
@@ -12,7 +12,7 @@
     <ProjectReference Include="..\DiscUtils.Streams\DiscUtils.Streams.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net50' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="5.0.0" />
   </ItemGroup>

--- a/Library/DiscUtils.Registry/RegistryCorruptException.cs
+++ b/Library/DiscUtils.Registry/RegistryCorruptException.cs
@@ -24,16 +24,12 @@ using System;
 
 namespace DiscUtils.Registry
 {
-#if !NETSTANDARD1_5
     using System.Runtime.Serialization;
-#endif
 
     /// <summary>
     /// Exception thrown when some corruption is found in the registry hive.
     /// </summary>
-#if !NETSTANDARD1_5
     [Serializable]
-#endif
     public class RegistryCorruptException : Exception
     {
         /// <summary>
@@ -56,7 +52,6 @@ namespace DiscUtils.Registry
         public RegistryCorruptException(string message, Exception innerException)
             : base(message, innerException) {}
 
-#if !NETSTANDARD1_5
         /// <summary>
         /// Initializes a new instance of the RegistryCorruptException class.
         /// </summary>
@@ -66,6 +61,5 @@ namespace DiscUtils.Registry
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/Library/DiscUtils.Vhd/FileChecker.cs
+++ b/Library/DiscUtils.Vhd/FileChecker.cs
@@ -24,9 +24,7 @@ using System;
 using System.IO;
 using DiscUtils.Internal;
 using DiscUtils.Streams;
-#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
-#endif
 
 namespace DiscUtils.Vhd
 {
@@ -418,9 +416,7 @@ namespace DiscUtils.Vhd
             }
         }
 
-#if !NETSTANDARD1_5
         [Serializable]
-#endif
         private sealed class AbortException : InvalidFileSystemException
         {
             

--- a/Library/DiscUtils/DiscUtils.csproj
+++ b/Library/DiscUtils/DiscUtils.csproj
@@ -33,24 +33,6 @@
     <ProjectReference Include="..\DiscUtils.Wim\DiscUtils.Wim.csproj" />
     <ProjectReference Include="..\DiscUtils.Xfs\DiscUtils.Xfs.csproj" />
     <ProjectReference Include="..\DiscUtils.Xva\DiscUtils.Xva.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
-    <ProjectReference Include="..\DiscUtils.Net\DiscUtils.Net.csproj" />
-    <ProjectReference Include="..\DiscUtils.OpticalDiscSharing\DiscUtils.OpticalDiscSharing.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <ProjectReference Include="..\DiscUtils.Net\DiscUtils.Net.csproj" />
-    <ProjectReference Include="..\DiscUtils.OpticalDiscSharing\DiscUtils.OpticalDiscSharing.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <ProjectReference Include="..\DiscUtils.Net\DiscUtils.Net.csproj" />
-    <ProjectReference Include="..\DiscUtils.OpticalDiscSharing\DiscUtils.OpticalDiscSharing.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <ProjectReference Include="..\DiscUtils.Net\DiscUtils.Net.csproj" />
     <ProjectReference Include="..\DiscUtils.OpticalDiscSharing\DiscUtils.OpticalDiscSharing.csproj" />
   </ItemGroup>

--- a/Library/DiscUtils/SetupHelper.cs
+++ b/Library/DiscUtils/SetupHelper.cs
@@ -15,11 +15,8 @@ using DiscUtils.SquashFs;
 using DiscUtils.Udf;
 using DiscUtils.Wim;
 using DiscUtils.Xfs;
-
-#if !NETSTANDARD1_5
 using DiscUtils.Net.Dns;
 using DiscUtils.OpticalDiscSharing;
-#endif
 
 namespace DiscUtils.Complete
 {
@@ -35,14 +32,10 @@ namespace DiscUtils.Complete
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(HfsPlusFileSystem)));
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(Iscsi.Disk)));
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(BuildFileInfo)));
-#if !NETSTANDARD1_5
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(DnsClient)));
-#endif
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(Nfs3Status)));
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(NtfsFileSystem)));
-#if !NETSTANDARD1_5
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(DiscInfo)));
-#endif
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(Disc)));
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(RegistryHive)));
             Setup.SetupHelper.RegisterAssembly(ReflectionHelper.GetAssembly(typeof(SdiFile)));

--- a/Library/common-library.props
+++ b/Library/common-library.props
@@ -3,7 +3,7 @@
   
   <!-- Package related stuff -->
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net40;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net40;net45;net5.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net20</TargetFrameworks>
     
     <PackageProjectUrl>https://github.com/DiscUtils/DiscUtils</PackageProjectUrl>


### PR DESCRIPTION
This PR

- Adds the `net5.0` target
- Removes dependencies on packages which ship inbox in `netstandard2.0` and `net5.0` (such as `System.IO.FileSystem.DriveInfo` , `System.Threading.Thread`, `System.Net.Sockets` and `System.Xml.XmlDocument`.
- Annotates DicsUtils.Ntfs as Windows-only on net5.0, because it has a dependency on `SecurityIdentifier` (via `Quotas.cs`) which is marked as Windows-only.