### PR TITLE
Use `dotnet tool` to install GitVersion

### DIFF
--- a/Library/DiscUtils.Registry/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Registry/Properties/AssemblyInfo.cs
@@ -1,10 +1,18 @@
 ﻿using System.Runtime.InteropServices;
 
+#if NET5_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
+
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 
 [assembly: ComVisible(false)]
+
+#if NET5_0_OR_GREATER
+[assembly: SupportedOSPlatform("windows")]
+#endif
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 

--- a/Library/DiscUtils.Vhdx/Metadata.cs
+++ b/Library/DiscUtils.Vhdx/Metadata.cs
@@ -25,7 +25,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using DiscUtils.CoreCompat;
 using DiscUtils.Streams;
-#if !NETSTANDARD
+#if !NET5_0_OR_GREATER
 using System.Security.Permissions;
 #endif
 
@@ -117,7 +117,7 @@ namespace DiscUtils.Vhdx
             return entry.Length;
         }
 
-#if !NETSTANDARD
+#if !NET5_0_OR_GREATER
         [SecurityPermission(SecurityAction.Demand, UnmanagedCode = true)]
 #endif
         private static uint AddEntryValue<T>(T data, Writer<T> writer, Guid id, MetadataEntryFlags flags,
@@ -155,7 +155,7 @@ namespace DiscUtils.Vhdx
             return default(T);
         }
 
-#if !NETSTANDARD
+#if !NET5_0_OR_GREATER
         [SecurityPermission(SecurityAction.Demand, UnmanagedCode = true)]
 #endif
         private T ReadValue<T>(Guid itemId, bool isUser, Reader<T> reader)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,10 @@
 image: Visual Studio 2019
 install:
-  - choco install gitversion.portable -pre -y
+  - dotnet tool install --global GitVersion.Tool
 
 before_build:
   - ps: >-
-      $version = ConvertFrom-Json $($(GitVersion) -join "")
+      $version = ConvertFrom-Json $($(dotnet gitversion) -join "")
       
       $content = Get-Content .\Version.template.props -Raw;
       $content = $content.Replace("&InformationalVersion&", $version.InformationalVersion);


### PR DESCRIPTION
This removes a dependency on chocolatey during the build process.