### PR TITLE
BZip2DecoderStream: Return 0 when reading beyond the end of the stream

### DIFF
--- a/Library/DiscUtils.Core/Compression/BZip2DecoderStream.cs
+++ b/Library/DiscUtils.Core/Compression/BZip2DecoderStream.cs
@@ -172,7 +172,7 @@ namespace DiscUtils.Compression
 
             if (_eof)
             {
-                throw new IOException("Attempt to read beyond end of stream");
+                return 0;
             }
 
             if (count == 0)

--- a/Tests/LibraryTests/Compression/BZip2DecoderStreamTest.cs
+++ b/Tests/LibraryTests/Compression/BZip2DecoderStreamTest.cs
@@ -67,6 +67,9 @@ namespace LibraryTests.Compression
             int numRead = decoder.Read(buffer, 0, 1024);
             Assert.Equal(21, numRead);
 
+            // Reading beyond the end of the stream will return 0 bytes
+            Assert.Equal(0, decoder.Read(buffer, numRead, 1024 - numRead));
+
             string s = Encoding.ASCII.GetString(buffer, 0, numRead);
             Assert.Equal("This is a test string", s);
         }


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/api/system.io.stream.read?view=net-5.0

> (Returns) zero (0) if the end of the stream has been reached.