### PR TITLE
FatFileSystem: Make sure the 437 codepage is available.

### DIFF
--- a/Library/DiscUtils.Core/CoreCompat/EncodingHelper.cs
+++ b/Library/DiscUtils.Core/CoreCompat/EncodingHelper.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD
+﻿#if !NET20 && !NET40 && !NET45
 using System.Text;
 #endif
 
@@ -15,7 +15,7 @@ namespace DiscUtils.CoreCompat
 
             _registered = true;
 
-#if NETSTANDARD
+#if !NET20 && !NET40 && !NET45
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 #endif
         }


### PR DESCRIPTION
The fat filesystem uses the 437 codepage. Let's make sure it's available by registering the `CodePagesEncodingProvider` in the static constructor.

Fixes the unit test errors observed in GitHub actions.