### PR TITLE
Re-enable AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+image: Visual Studio 2019
+
+before_build:
+  - cmd: dotnet restore
+
+build_script:
+  - cmd: dotnet build -c Debug --no-restore
+
+test_script:
+  - cmd: dotnet test Tests\LibraryTests\LibraryTests.csproj -c Release --logger:trx -- RunConfiguration.TargetPlatform="x64" RunConfiguration.DisableParallelization="true"
+
+artifacts:
+  - path: '**\*.nupkg'
+  - path: '**\*.snupkg'
+
+after_test:
+  - cmd: dotnet pack -c Release
+
+deploy:
+  - provider: NuGet
+    server: https://www.myget.org/F/discutils/api/v2/package
+    symbol_server: https://www.myget.org/F/discutils/api/v2/package
+    api_key:
+      secure: foGROcPrYEku4LqHLdwidY8kXnpLsAB1YOBufMY0P9AptYpUzySgx5gezRcZ9vma
+    on:
+      # We push on all develop commits
+      branch: develop
+
+  - provider: NuGet
+    api_key:
+      secure: 1zdVvAQJbpFDsKJS/TXQLc6GI6SlZueTSCcL7xbK6QMisvL8V5nhLFgrceLfp1Ak
+    on:
+      # Only push on tagged master commits
+      branch: master
+      APPVEYOR_REPO_TAG: true


### PR DESCRIPTION
The GitHub Actions build script can't publish to MyGet/NuGet (yet), and GitHub artifacts require authentication (which is not always practical).

This PR brings back the AppVeyor so NuGet packages of the develop branch can be consumed from MyGet.