### PR TITLE
ZlibStream: Only verify Adler32 checksum if all data was read

### DIFF
--- a/Tests/LibraryTests/Compression/ZlibStreamTest.cs
+++ b/Tests/LibraryTests/Compression/ZlibStreamTest.cs
@@ -83,5 +83,28 @@ namespace LibraryTests.Compression
                 }
             });
         }
+
+        /// <summary>
+        /// <see cref="ZlibStream.Dispose(bool)"/> does not throw when disposing of a stream which has not been
+        /// read fully.
+        /// </summary>
+        [Fact]
+        public void Dispose_NoDataRead_DoesNotThrow()
+        {
+            byte[] testData = Encoding.ASCII.GetBytes("This is a test string");
+
+            MemoryStream compressedStream = new MemoryStream();
+
+            using (ZlibStream zs = new ZlibStream(compressedStream, CompressionMode.Compress, true))
+            {
+                zs.Write(testData, 0, testData.Length);
+            }
+
+            compressedStream.Position = 0;
+            using (ZlibStream uzs = new ZlibStream(compressedStream, CompressionMode.Decompress, true))
+            {
+                uzs.Dispose();
+            }
+        }
     }
 }


### PR DESCRIPTION
The `.Dispose` method in `ZlibStream` will attempt to verify the Adler32 checksum at the end of the stream.

The check will fail if not all decompressed data was read, since not all data was checksummed and the checksum will not match.

This PR updates the `.Dispose` logic a bit to _only_ validate the checksum when we're sure all decompressed data has been read.