### PR TITLE
DiskClone run fixed.

### DIFF
--- a/Library/DiscUtils.Core/DiskImageBuilder.cs
+++ b/Library/DiscUtils.Core/DiskImageBuilder.cs
@@ -34,8 +34,6 @@ namespace DiscUtils
     /// </summary>
     public abstract class DiskImageBuilder
     {
-        private static Dictionary<string, VirtualDiskFactory> _typeMap;
-
         /// <summary>
         /// Gets or sets the geometry of this disk, as reported by the BIOS, will be implied from the content stream if not set.
         /// </summary>
@@ -64,19 +62,6 @@ namespace DiscUtils
             get { return false; }
         }
 
-        private static Dictionary<string, VirtualDiskFactory> TypeMap
-        {
-            get
-            {
-                if (_typeMap == null)
-                {
-                    InitializeMaps();
-                }
-
-                return _typeMap;
-            }
-        }
-
         /// <summary>
         /// Gets an instance that constructs the specified type (and variant) of virtual disk image.
         /// </summary>
@@ -86,7 +71,7 @@ namespace DiscUtils
         public static DiskImageBuilder GetBuilder(string type, string variant)
         {
             VirtualDiskFactory factory;
-            if (!TypeMap.TryGetValue(type, out factory))
+            if (!VirtualDiskManager.TypeMap.TryGetValue(type, out factory))
             {
                 throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Unknown disk type '{0}'", type), nameof(type));
             }
@@ -105,22 +90,5 @@ namespace DiscUtils
         /// to each logical file that comprises the disk image.  For example, given a base name
         /// 'foo', the files 'foo.vmdk' and 'foo-flat.vmdk' could be returned.</remarks>
         public abstract DiskImageFileSpecification[] Build(string baseName);
-
-        private static void InitializeMaps()
-        {
-            Dictionary<string, VirtualDiskFactory> typeMap = new Dictionary<string, VirtualDiskFactory>();
-
-            foreach (Type type in ReflectionHelper.GetAssembly(typeof(VirtualDisk)).GetTypes())
-            {
-                VirtualDiskFactoryAttribute attr = (VirtualDiskFactoryAttribute)ReflectionHelper.GetCustomAttribute(type, typeof(VirtualDiskFactoryAttribute), false);
-                if (attr != null)
-                {
-                    VirtualDiskFactory factory = (VirtualDiskFactory)Activator.CreateInstance(type);
-                    typeMap.Add(attr.Type, factory);
-                }
-            }
-
-            _typeMap = typeMap;
-        }
     }
 }

--- a/Utilities/DiskClone/DiskClone.csproj
+++ b/Utilities/DiskClone/DiskClone.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Library\DiscUtils.Containers\DiscUtils.Containers.csproj" />
     <ProjectReference Include="..\DiscUtils.Common\DiscUtils.Common.csproj" />
     <ProjectReference Include="..\..\Library\DiscUtils.Core\DiscUtils.Core.csproj" />
     <ProjectReference Include="..\..\Library\DiscUtils.Ntfs\DiscUtils.Ntfs.csproj" />

--- a/Utilities/DiskClone/Program.cs
+++ b/Utilities/DiskClone/Program.cs
@@ -27,6 +27,7 @@ using System.Runtime.InteropServices;
 using System.Security.Principal;
 using DiscUtils;
 using DiscUtils.Common;
+using DiscUtils.Containers;
 using DiscUtils.Ntfs;
 using DiscUtils.Partitions;
 using DiscUtils.Streams;
@@ -49,6 +50,7 @@ namespace DiskClone
 
         static void Main(string[] args)
         {
+            SetupHelper.SetupContainers();
             Program program = new Program();
             program.Run(args);
         }


### PR DESCRIPTION
Added DiscUtils.Containers reference to a DiskClone utility.
Use VirtualDiskManager.TypeMap instead of own in the DiskImageBuilder. This fixes DiskClone utility (the only one using DiskImageBuilder.GetBuilder()).