### PR TITLE
Resolve symlink

### DIFF
--- a/Library/DiscUtils.Core/Vfs/VfsFileSystem.cs
+++ b/Library/DiscUtils.Core/Vfs/VfsFileSystem.cs
@@ -698,7 +698,7 @@ namespace DiscUtils.Vfs
                     {
                         results.Add(Utilities.CombinePaths(resultPrefixPath, FormatFileName(entry.FileName)));
                     }
-               }
+                }
 
                 if (subFolders && isDir)
                 {

--- a/Library/DiscUtils.Core/Vfs/VfsFileSystem.cs
+++ b/Library/DiscUtils.Core/Vfs/VfsFileSystem.cs
@@ -685,6 +685,10 @@ namespace DiscUtils.Vfs
                 {
                     entry = ResolveSymlink(entry, path + "\\" + entry.FileName);
                 }
+                if(entry == null)
+                {
+                    continue;
+                }
 
                 bool isDir = entry.IsDirectory;
 
@@ -694,7 +698,7 @@ namespace DiscUtils.Vfs
                     {
                         results.Add(Utilities.CombinePaths(resultPrefixPath, FormatFileName(entry.FileName)));
                     }
-                }
+               }
 
                 if (subFolders && isDir)
                 {
@@ -723,15 +727,16 @@ namespace DiscUtils.Vfs
 
                 currentPath = Utilities.ResolvePath(currentPath.TrimEnd('\\'), symlink.TargetPath);
                 currentEntry = GetDirectoryEntry(currentPath);
+
                 if (currentEntry == null)
                 {
-                    throw new FileNotFoundException("Unable to resolve symlink", path);
+                    break;
                 }
 
                 --resolvesLeft;
             }
 
-            if (currentEntry.IsSymlink)
+            if (currentEntry != null && currentEntry.IsSymlink)
             {
                 throw new FileNotFoundException("Unable to resolve symlink - too many links", path);
             }


### PR DESCRIPTION
We found a directory has several symbolic links which point to target paths that do not exist, so a FileNotFound exception is thrown and it blocks getting any other files from that folder.

This fix is to ignore the errors when a symlink points to a target path that does not exist instead of throwing exceptions.
Tested changes on CentOS, Ubuntu, Windows, and Mariner OS.

Similar issue reported before : https://github.com/DiscUtils/DiscUtils/issues/141
