### PR TITLE
Fix sector size calculation for Disk images

### DIFF
--- a/Library/DiscUtils.Iso9660/BuildParameters.cs
+++ b/Library/DiscUtils.Iso9660/BuildParameters.cs
@@ -26,12 +26,16 @@ namespace DiscUtils.Iso9660
     {
         public BuildParameters()
         {
+            ManufacturerId = ".Net DiscUtils";
             VolumeIdentifier = string.Empty;
             UseJoliet = true;
         }
 
+        public string ManufacturerId { get; set; }
+
         public bool UseJoliet { get; set; }
 
         public string VolumeIdentifier { get; set; }
+
     }
 }

--- a/Library/DiscUtils.Iso9660/CDBuilder.cs
+++ b/Library/DiscUtils.Iso9660/CDBuilder.cs
@@ -108,6 +108,26 @@ namespace DiscUtils.Iso9660
         }
 
         /// <summary>
+        /// Gets or sets the Manufacturer ID for the ISO file.
+        /// </summary>
+        /// <remarks>
+        /// Must be a valid identifier, i.e. max 23 characters.
+        /// </remarks>
+        public string ManufacturerId
+        {
+            get { return _buildParams.ManufacturerId; }
+
+            set
+            {
+                if (value.Length > 23)
+                {
+                    throw new ArgumentException("Not a valid volume identifier");
+                }
+                _buildParams.ManufacturerId = value;
+            }
+        }
+
+        /// <summary>
         /// Sets the boot image for the ISO image.
         /// </summary>
         /// <param name="image">Stream containing the boot image.</param>
@@ -276,6 +296,7 @@ namespace DiscUtils.Iso9660
 
                 byte[] bootCatalog = new byte[IsoUtilities.SectorSize];
                 BootValidationEntry bve = new BootValidationEntry();
+                bve.ManfId = ManufacturerId;
                 bve.WriteTo(bootCatalog, 0x00);
                 _bootEntry.ImageStart = (uint)MathUtilities.Ceil(bootImagePos, IsoUtilities.SectorSize);
                 if (_bootEntry.BootMediaType != BootDeviceEmulation.NoEmulation)

--- a/Library/DiscUtils.Iso9660/VfsCDReader.cs
+++ b/Library/DiscUtils.Iso9660/VfsCDReader.cs
@@ -460,7 +460,6 @@ namespace DiscUtils.Iso9660
                 case BootDeviceEmulation.Diskette2880KiB:
                     return 2880 * 1024 / Sizes.Sector;
                 case BootDeviceEmulation.HardDisk:
-                    return GetBootInitialEntry().SectorCount;
                 case BootDeviceEmulation.NoEmulation:
                 default:
                     BootInitialEntry initialEntry = GetBootInitialEntry();

--- a/Library/DiscUtils.Iso9660/VfsCDReader.cs
+++ b/Library/DiscUtils.Iso9660/VfsCDReader.cs
@@ -460,6 +460,7 @@ namespace DiscUtils.Iso9660
                 case BootDeviceEmulation.Diskette2880KiB:
                     return 2880 * 1024 / Sizes.Sector;
                 case BootDeviceEmulation.HardDisk:
+                    return GetBootInitialEntry().SectorCount;
                 case BootDeviceEmulation.NoEmulation:
                 default:
                     BootInitialEntry initialEntry = GetBootInitialEntry();


### PR DESCRIPTION
A fix for a bug mentioned in #247: implementing fixes for sector size detection for bootable images.

We either calculate the sector count based on the emulated floppy size, or we look at the boot sector of the image to see if it's a valid boot sector. If so, we retrieve the sector count from there.

When writing to the disk, if we are writing a boot image with emulation, we mark the sector count as 1 in the boot catalog.