### PR TITLE
fix GC thread crash in WimFileSystem dispose

### DIFF
--- a/Library/DiscUtils.Wim/WimFileSystem.cs
+++ b/Library/DiscUtils.Wim/WimFileSystem.cs
@@ -531,17 +531,17 @@ namespace DiscUtils.Wim
         /// <param name="disposing"><c>true</c> if disposing, else <c>false</c>.</param>
         protected override void Dispose(bool disposing)
         {
-            try
+            if (disposing)
             {
-                _metaDataStream.Dispose();
-                _metaDataStream = null;
+                if (_metaDataStream != null)
+                {
+                    _metaDataStream.Dispose();
+                    _metaDataStream = null;
+                }
 
                 _file = null;
             }
-            finally
-            {
-                base.Dispose(disposing);
-            }
+            base.Dispose(disposing);
         }
 
         private static void SplitFileName(string path, out string filePart, out string altStreamPart)


### PR DESCRIPTION
If this code in constructor of WimFileSystem throws

> ShortResourceHeader metaDataFileInfo = _file.LocateImage(index);
if (metaDataFileInfo == null)
{
    throw new ArgumentException("No such image: " + index, nameof(index));
}

_metaDataStream is never set

Later the GC will call the deconstructor in `DiscFileSystem` `Dispose(false)`  that will throw when _metaDataStream is not set

This is a major problem for us when trying to work with a corrupt wim-image.