### PR TITLE
VfsFileSystem: ignore not supported symlink

### DIFF
--- a/Library/DiscUtils.Core/Vfs/VfsFileSystem.cs
+++ b/Library/DiscUtils.Core/Vfs/VfsFileSystem.cs
@@ -683,11 +683,27 @@ namespace DiscUtils.Vfs
 
                 if (entry.IsSymlink)
                 {
-                    entry = ResolveSymlink(entry, path + "\\" + entry.FileName);
-                }
-                if(entry == null)
-                {
-                    continue;
+                    try
+                    {
+                        entry = ResolveSymlink(entry, path + "\\" + entry.FileName);
+
+                        if (entry == null)
+                        {
+                            // Symlink doesn't resolve to a valid entry, ignore it
+                            continue;
+                        }
+                    }
+                    catch (NotImplementedException)
+                    {
+                        // If the underlying doesn't support symlink, ignore it to still allow
+                        // to work with all other entries
+                        continue;
+                    }
+                    catch (NotSupportedException)
+                    {
+                        // Same as for NotImplementedException
+                        continue;
+                    }
                 }
 
                 bool isDir = entry.IsDirectory;


### PR DESCRIPTION
If resolving a symlink throws a NotImplementedException or NotSupportedException, ignore the symlink.

This allows to open archives of types for which the symlink are not supported yet, for example squashfs.