### PR TITLE
Framework Targets

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2
@@ -18,9 +18,9 @@ jobs:
     - run: git fetch --tags
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 7.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2
@@ -20,10 +20,10 @@ jobs:
         lfs: 'true'
     # We do not need to fetch tags, as we're already at a tagged build - it should be available automatically
 
-    - name: Setup .NET Core 5.0
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '7.0.x'
 
     - name: Pack
       run: dotnet pack -c Release -o ${{ github.workspace }}/build

--- a/Library/DiscUtils.BootConfig/DiscUtils.BootConfig.csproj
+++ b/Library/DiscUtils.BootConfig/DiscUtils.BootConfig.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>DiscUtils BootConfig parser</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;BootConfig</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Btrfs/DiscUtils.Btrfs.csproj
+++ b/Library/DiscUtils.Btrfs/DiscUtils.Btrfs.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils Btrfs</Description>
     <Authors>Bianco Veigel</Authors>
     <PackageTags>DiscUtils;Btrfs</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Containers/DiscUtils.Containers.csproj
+++ b/Library/DiscUtils.Containers/DiscUtils.Containers.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils, meta-package with container formats such as WIM, DMG, VHD, VHDX, XVA, VMDK</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;VHD;VHDX;XVA;VMDK;DMG</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Core/DiscUtils.Core.csproj
+++ b/Library/DiscUtils.Core/DiscUtils.Core.csproj
@@ -1,20 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Implementation of the ISO, UDF, FAT and NTFS file systems is now fairly stable. VHD, XVA, VMDK and VDI disk formats are implemented, as well as read/write Registry support. The library also includes a simple iSCSI initiator, for accessing disks via iSCSI and an NFS client implementation.</Description>
     <AssemblyTitle>DiscUtils (for .NET and .NET Core), core library that supports parts of DiscUtils</AssemblyTitle>
     <Authors>Kenneth Bell;Quamotion;LordMike</Authors>
     <PackageTags>DiscUtils;VHD;VDI;XVA;VMDK;ISO;NTFS;EXT2FS</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\DiscUtils.Streams\DiscUtils.Streams.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="System.Security.AccessControl" Version="5.0.0" />
-    
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup>
     <PackageReference Include="System.Security.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>

--- a/Library/DiscUtils.Dmg/DiscUtils.Dmg.csproj
+++ b/Library/DiscUtils.Dmg/DiscUtils.Dmg.csproj
@@ -4,6 +4,7 @@
     <Authors>Kenneth Bell;LordMike;quamotion</Authors>
     <PackageTags>DiscUtils;dmg</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Ext/DiscUtils.Ext.csproj
+++ b/Library/DiscUtils.Ext/DiscUtils.Ext.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils ext filesystem parser</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;Filesystem;ext</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Fat/DiscUtils.Fat.csproj
+++ b/Library/DiscUtils.Fat/DiscUtils.Fat.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils FAT filesystem parser</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;Filesystem;FAT</PackageTags>
+	<TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.FileSystems/DiscUtils.FileSystems.csproj
+++ b/Library/DiscUtils.FileSystems/DiscUtils.FileSystems.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils, meta-package with filesystems</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;Filesystem;NTFS;ext;Hfs+;HfsPlus;FAT</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.HfsPlus/DiscUtils.HfsPlus.csproj
+++ b/Library/DiscUtils.HfsPlus/DiscUtils.HfsPlus.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils Hfs+ filesystem parser</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;Filesystem;Hfs+;HfsPlus</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Iscsi/DiscUtils.Iscsi.csproj
+++ b/Library/DiscUtils.Iscsi/DiscUtils.Iscsi.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils iSCSI</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;iSCSI</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Iso9660/DiscUtils.Iso9660.csproj
+++ b/Library/DiscUtils.Iso9660/DiscUtils.Iso9660.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils Iso9660</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;Optical;Iso9660</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Lvm/DiscUtils.Lvm.csproj
+++ b/Library/DiscUtils.Lvm/DiscUtils.Lvm.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils LVM</Description>
     <Authors>Bianco Veigel</Authors>
     <PackageTags>DiscUtils;Lvm</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Net/DiscUtils.Net.csproj
+++ b/Library/DiscUtils.Net/DiscUtils.Net.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils NET</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;NET;DNS</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Nfs/DiscUtils.Nfs.csproj
+++ b/Library/DiscUtils.Nfs/DiscUtils.Nfs.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils Nfs</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;Nfs</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Ntfs/DiscUtils.Ntfs.csproj
+++ b/Library/DiscUtils.Ntfs/DiscUtils.Ntfs.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils NTFS filesystem parser</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;Filesystem;NTFS</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.OpticalDiscSharing/DiscUtils.OpticalDiscSharing.csproj
+++ b/Library/DiscUtils.OpticalDiscSharing/DiscUtils.OpticalDiscSharing.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils OpticalDiscSharing</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;OpticalDiscSharing</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.OpticalDisk/DiscUtils.OpticalDisk.csproj
+++ b/Library/DiscUtils.OpticalDisk/DiscUtils.OpticalDisk.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils OpticalDisk</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;Optical;OpticalDisk</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Registry/DiscUtils.Registry.csproj
+++ b/Library/DiscUtils.Registry/DiscUtils.Registry.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils Registry</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;Registry</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Sdi/DiscUtils.Sdi.csproj
+++ b/Library/DiscUtils.Sdi/DiscUtils.Sdi.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils Sdi</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;Sdi</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.SquashFs/DiscUtils.SquashFs.csproj
+++ b/Library/DiscUtils.SquashFs/DiscUtils.SquashFs.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils SquashFs filesystem parser</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;Filesystem;SquashFs</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Streams/DiscUtils.Streams.csproj
+++ b/Library/DiscUtils.Streams/DiscUtils.Streams.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils Streams</Description>
     <Authors>Kenneth Bell;LordMike;Bianco Veigel</Authors>
     <PackageTags>DiscUtils;Streams</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/Library/DiscUtils.Swap/DiscUtils.Swap.csproj
+++ b/Library/DiscUtils.Swap/DiscUtils.Swap.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils Swap</Description>
     <Authors>Bianco Veigel</Authors>
     <PackageTags>DiscUtils;Swap</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Transports/DiscUtils.Transports.csproj
+++ b/Library/DiscUtils.Transports/DiscUtils.Transports.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils, meta-package with transports, such as iSCSI and NFS</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;iSCSI;NFS</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Udf/DiscUtils.Udf.csproj
+++ b/Library/DiscUtils.Udf/DiscUtils.Udf.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils UDF filesystem parser.</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;Filesystem;UDF</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Vdi/DiscUtils.Vdi.csproj
+++ b/Library/DiscUtils.Vdi/DiscUtils.Vdi.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils Vdi</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;Vdi</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Vhd/DiscUtils.Vhd.csproj
+++ b/Library/DiscUtils.Vhd/DiscUtils.Vhd.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils VHD</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;VHD</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Vhdx/DiscUtils.Vhdx.csproj
+++ b/Library/DiscUtils.Vhdx/DiscUtils.Vhdx.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils VHDX</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;VHDX</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Vmdk/DiscUtils.Vmdk.csproj
+++ b/Library/DiscUtils.Vmdk/DiscUtils.Vmdk.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils VMDK</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;VMDK</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Wim/DiscUtils.Wim.csproj
+++ b/Library/DiscUtils.Wim/DiscUtils.Wim.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils WIM</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;WIM</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Xfs/DiscUtils.Xfs.csproj
+++ b/Library/DiscUtils.Xfs/DiscUtils.Xfs.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils XFS</Description>
     <Authors>Bianco Veigel</Authors>
     <PackageTags>DiscUtils;Xfs</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils.Xva/DiscUtils.Xva.csproj
+++ b/Library/DiscUtils.Xva/DiscUtils.Xva.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils XVA</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils;XVA</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Library/DiscUtils/DiscUtils.csproj
+++ b/Library/DiscUtils/DiscUtils.csproj
@@ -3,6 +3,7 @@
     <Description>DiscUtils, complete meta-package</Description>
     <Authors>Kenneth Bell;LordMike</Authors>
     <PackageTags>DiscUtils</PackageTags>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/LibraryTests/LibraryTests.csproj
+++ b/Tests/LibraryTests/LibraryTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-tests.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>LibraryTests</AssemblyName>
     <PackageId>LibraryTests</PackageId>

--- a/Utilities/BCDDump/BCDDump.csproj
+++ b/Utilities/BCDDump/BCDDump.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Utilities/DiscUtils.Common/DiscUtils.Common.csproj
+++ b/Utilities/DiscUtils.Common/DiscUtils.Common.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
     <DebugType>portable</DebugType>
   </PropertyGroup>
 

--- a/Utilities/DiscUtils.Diagnostics/DiscUtils.Diagnostics.csproj
+++ b/Utilities/DiscUtils.Diagnostics/DiscUtils.Diagnostics.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -15,11 +15,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Library\DiscUtils.Core\DiscUtils.Core.csproj" />
     <ProjectReference Include="..\DiscUtils.Common\DiscUtils.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/Utilities/DiscUtils.PowerShell/DiscUtils.PowerShell.csproj
+++ b/Utilities/DiscUtils.PowerShell/DiscUtils.PowerShell.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -20,7 +20,7 @@
     <PackageReference Include="System.Management.Automation" Version="6.1.7601.17515" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+  <ItemGroup>
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
@@ -32,7 +32,7 @@
     </Compile>
   </ItemGroup>
 
-  <ItemGroup>
+	<ItemGroup>
     <None Update="DiscUtils.Format.ps1xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Utilities/DiskClone/DiskClone.csproj
+++ b/Utilities/DiskClone/DiskClone.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/Utilities/DiskDump/DiskDump.csproj
+++ b/Utilities/DiskDump/DiskDump.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Utilities/DmgExtract/DmgExtract.csproj
+++ b/Utilities/DmgExtract/DmgExtract.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>

--- a/Utilities/ExternalFileSystem/ExternalFileSystem.csproj
+++ b/Utilities/ExternalFileSystem/ExternalFileSystem.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Utilities/FileExtract/FileExtract.csproj
+++ b/Utilities/FileExtract/FileExtract.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Utilities/FileRecover/FileRecover.csproj
+++ b/Utilities/FileRecover/FileRecover.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Utilities/ISOCreate/ISOCreate.csproj
+++ b/Utilities/ISOCreate/ISOCreate.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Utilities/MSBuildTask/CreateIso.cs
+++ b/Utilities/MSBuildTask/CreateIso.cs
@@ -20,15 +20,13 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using System.Threading.Tasks;
-
 namespace MSBuildTask
 {
-    using System;
-    using System.IO;
     using DiscUtils.Iso9660;
     using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
+    using System;
+    using System.IO;
 
     public class CreateIso : Task
     {

--- a/Utilities/MSBuildTask/CreateSquashFileSystem.cs
+++ b/Utilities/MSBuildTask/CreateSquashFileSystem.cs
@@ -22,12 +22,10 @@
 
 namespace MSBuildTask
 {
-    using System;
-    using System.Collections.Generic;
-    using DiscUtils.Iso9660;
+    using DiscUtils.SquashFs;
     using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
-    using DiscUtils.SquashFs;
+    using System;
 
     public class CreateSquashFileSystem : Task
     {

--- a/Utilities/MSBuildTask/MSBuildTask.csproj
+++ b/Utilities/MSBuildTask/MSBuildTask.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\Library\DiscUtils.SquashFs\DiscUtils.SquashFs.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+  <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
   </ItemGroup>

--- a/Utilities/NTFSDump/NTFSDump.csproj
+++ b/Utilities/NTFSDump/NTFSDump.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Utilities/ODSBrowse/ODSBrowse.csproj
+++ b/Utilities/ODSBrowse/ODSBrowse.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Utilities/OSClone/OSClone.csproj
+++ b/Utilities/OSClone/OSClone.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Utilities/VHDCreate/VHDCreate.csproj
+++ b/Utilities/VHDCreate/VHDCreate.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Utilities/VHDDump/VHDDump.csproj
+++ b/Utilities/VHDDump/VHDDump.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Utilities/VHDXDump/VHDXDump.csproj
+++ b/Utilities/VHDXDump/VHDXDump.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Utilities/VirtualDiskConvert/VirtualDiskConvert.csproj
+++ b/Utilities/VirtualDiskConvert/VirtualDiskConvert.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Utilities/VolInfo/VolInfo.csproj
+++ b/Utilities/VolInfo/VolInfo.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/Utilities/iSCSIBrowse/iSCSIBrowse.csproj
+++ b/Utilities/iSCSIBrowse/iSCSIBrowse.csproj
@@ -2,7 +2,7 @@
   <Import Project="../common-utilities.props" />
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>


### PR DESCRIPTION
Update library targets to netstandard2.0, net462, and net6.0.
Update test target to net6.0.
Update utility targets to netstandard2.0, net6.0, or net462.
Update github actions to run on windows 2022 and .net 7.0.
Optimize using directives in MSBuildTask.