### PR TITLE
Fix ExtentsFileBuffer.Read for sparse files with holes

### DIFF
--- a/Library/DiscUtils.Ext/Extent.cs
+++ b/Library/DiscUtils.Ext/Extent.cs
@@ -31,6 +31,7 @@ namespace DiscUtils.Ext
         public ushort FirstPhysicalBlockHi;
         public uint FirstPhysicalBlockLow;
         public ushort NumBlocks;
+        public bool IsInitialized;
 
         public ulong FirstPhysicalBlock
         {
@@ -48,6 +49,14 @@ namespace DiscUtils.Ext
             NumBlocks = EndianUtilities.ToUInt16LittleEndian(buffer, offset + 4);
             FirstPhysicalBlockHi = EndianUtilities.ToUInt16LittleEndian(buffer, offset + 6);
             FirstPhysicalBlockLow = EndianUtilities.ToUInt32LittleEndian(buffer, offset + 8);
+
+            // Mask out high-order bit of NumBlocks if needed.  See https://www.kernel.org/doc/html/v4.19/filesystems/ext4/ondisk/#extent-tree
+            IsInitialized = NumBlocks <= 0x8000;
+            if (!IsInitialized)
+            {
+                NumBlocks &= 0x7FFF;
+            }
+
             return 12;
         }
 


### PR DESCRIPTION
Fix for ExtentsFileBuffer.Read, which reads a portion of the contents of a single file in an ext file system.

The old code relied on a private method FindExtent which, given the next logical block number to read in the file, sometimes returned the extent containing that block but sometimes returned a prior extent. This logic was sufficient for non-sparse files without "holes" but could not properly handle sparse files. In the presence of holes, the Read method could fall into an infinite loop trying to read the file but never making progress.

The new code redefines FindExtent to return the extent containing a given logical block or, if none, the first extent beyond it. Given this information, the Read method is guaranteed to always make forward progress.

This pull request also fixes a problem in which the high-order bit of the Extent.NumBlocks field is misinterpreted. That bit is used as a flag by the Linux kernel to indicate an unwritten extent, and should not be considered part of the actual block count.